### PR TITLE
Fix for mismatching foreign id's on join

### DIFF
--- a/src/main/java/com/j256/ormlite/field/FieldType.java
+++ b/src/main/java/com/j256/ormlite/field/FieldType.java
@@ -63,6 +63,7 @@ public class FieldType {
 	private final String generatedIdSequence;
 	private final Method fieldGetMethod;
 	private final Method fieldSetMethod;
+    private final Class<?> parentClass;
 
 	private DataPersister dataPersister;
 	private Object defaultValue;
@@ -91,6 +92,7 @@ public class FieldType {
 		this.tableName = tableName;
 		DatabaseType databaseType = connectionSource.getDatabaseType();
 		this.field = field;
+        this.parentClass = parentClass;
 
 		// post process our config settings
 		fieldConfig.postProcess();
@@ -944,7 +946,8 @@ public class FieldType {
 			return false;
 		}
 		FieldType other = (FieldType) arg;
-		return field.equals(other.field);
+		return field.equals(other.field) &&
+                (parentClass == null ? other.parentClass == null : parentClass.equals(other.parentClass));
 	}
 
 	@Override


### PR DESCRIPTION
FieldType.equals() now also takes the class which is used to create the
table in consideration. Before it only used a Field object to determine
if two FieldTypes are equal. If two subclasses (B/C) inherit a field
annotated as ID from superclass A their ID FieldTypes would be equal,
which is not preferable because it could mess up joins on these IDs.
