### PR TITLE
Allow IS NULL and IS NOT NULL comparisons for all field types.

### DIFF
--- a/src/main/java/com/j256/ormlite/stmt/query/IsNotNull.java
+++ b/src/main/java/com/j256/ormlite/stmt/query/IsNotNull.java
@@ -1,31 +1,23 @@
 package com.j256.ormlite.stmt.query;
 
-import java.sql.SQLException;
-import java.util.List;
-
-import com.j256.ormlite.db.DatabaseType;
 import com.j256.ormlite.field.FieldType;
-import com.j256.ormlite.stmt.ArgumentHolder;
 import com.j256.ormlite.stmt.Where;
+
+import java.sql.SQLException;
 
 /**
  * Internal class handling the SQL 'IS NOT NULL' comparison query part. Used by {@link Where#isNull}.
  * 
  * @author graywatson
  */
-public class IsNotNull extends BaseComparison {
+public class IsNotNull extends NullTestBase {
 
 	public IsNotNull(String columnName, FieldType fieldType) throws SQLException {
-		super(columnName, fieldType, null, true);
+		super(columnName, fieldType);
 	}
 
 	@Override
-	public void appendOperation(StringBuilder sb) {
+	protected void appendOperation(StringBuilder sb) {
 		sb.append("IS NOT NULL ");
-	}
-
-	@Override
-	public void appendValue(DatabaseType databaseType, StringBuilder sb, List<ArgumentHolder> argList) {
-		// there is no value
 	}
 }

--- a/src/main/java/com/j256/ormlite/stmt/query/IsNull.java
+++ b/src/main/java/com/j256/ormlite/stmt/query/IsNull.java
@@ -1,31 +1,23 @@
 package com.j256.ormlite.stmt.query;
 
-import java.sql.SQLException;
-import java.util.List;
-
-import com.j256.ormlite.db.DatabaseType;
 import com.j256.ormlite.field.FieldType;
-import com.j256.ormlite.stmt.ArgumentHolder;
 import com.j256.ormlite.stmt.Where;
+
+import java.sql.SQLException;
 
 /**
  * Internal class handling the SQL 'IS NULL' comparison query part. Used by {@link Where#isNull}.
  * 
  * @author graywatson
  */
-public class IsNull extends BaseComparison {
+public class IsNull extends NullTestBase {
 
 	public IsNull(String columnName, FieldType fieldType) throws SQLException {
-		super(columnName, fieldType, null, true);
+		super(columnName, fieldType);
 	}
 
 	@Override
-	public void appendOperation(StringBuilder sb) {
+	protected void appendOperation(StringBuilder sb) {
 		sb.append("IS NULL ");
-	}
-
-	@Override
-	public void appendValue(DatabaseType databaseType, StringBuilder sb, List<ArgumentHolder> argList) {
-		// there is no value
 	}
 }

--- a/src/main/java/com/j256/ormlite/stmt/query/NullTestBase.java
+++ b/src/main/java/com/j256/ormlite/stmt/query/NullTestBase.java
@@ -1,0 +1,49 @@
+package com.j256.ormlite.stmt.query;
+
+import com.j256.ormlite.db.DatabaseType;
+import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.stmt.ArgumentHolder;
+
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * Internal base class for IS NULL and IS NOT NULL test operations.
+ * 
+ * @author André Wachter
+ */
+abstract class NullTestBase implements Clause {
+	protected final String columnName;
+	protected final FieldType fieldType;
+
+	protected NullTestBase(String columnName, FieldType fieldType) throws SQLException {
+		this.columnName = columnName;
+		this.fieldType = fieldType;
+	}
+
+	@Override
+	public void appendSql(DatabaseType databaseType, String tableName, StringBuilder sb, List<ArgumentHolder> argList)
+			throws SQLException {
+		if (tableName != null) {
+			databaseType.appendEscapedEntityName(sb, tableName);
+			sb.append('.');
+		}
+		databaseType.appendEscapedEntityName(sb, columnName);
+		sb.append(' ');
+		appendOperation(sb);
+	}
+
+	public String getColumnName() {
+		return columnName;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append(columnName).append(' ');
+		appendOperation(sb);
+		return sb.toString();
+	}
+
+	protected abstract void appendOperation(StringBuilder sb);
+}


### PR DESCRIPTION
This PR enables test for IS NULL and IS NOT NULL on all field types. Previously I would get an error like this

```
java.sql.SQLException: Field 'user_status' is of data type com.j256.ormlite.field.types.SerializableType@41479c18 which can not be compared in
```

when using QueryBuilder like this:

``` java
getDao(Model.class).queryBuilder().where().isNotNull("user_status").query();
```
