### PR TITLE
Since property pr

### DIFF
--- a/src/main/java/com/j256/ormlite/field/DatabaseField.java
+++ b/src/main/java/com/j256/ormlite/field/DatabaseField.java
@@ -311,6 +311,11 @@ public @interface DatabaseField {
 	 */
 	boolean readOnly() default false;
 
+    /**
+     * Specify since which version number this field is introduced
+     */
+    int since() default 1;
+
 	/*
 	 * NOTE to developers: if you add fields here you have to add them to the DatabaseFieldConfig,
 	 * DatabaseFieldConfigLoader, DatabaseFieldConfigLoaderTest, and DatabaseTableConfigUtil.

--- a/src/main/java/com/j256/ormlite/field/DatabaseFieldConfig.java
+++ b/src/main/java/com/j256/ormlite/field/DatabaseFieldConfig.java
@@ -59,6 +59,7 @@ public class DatabaseFieldConfig {
 	private boolean version;
 	private String foreignColumnName;
 	private boolean readOnly;
+    private int since;
 	// foreign collection field information
 	private boolean foreignCollection;
 	private boolean foreignCollectionEager;
@@ -518,6 +519,14 @@ public class DatabaseFieldConfig {
 		this.readOnly = readOnly;
 	}
 
+    public int getSince() {
+        return since;
+    }
+
+    public void setSince(int since) {
+        this.since = since;
+    }
+
 	/**
 	 * Create and return a config converted from a {@link Field} that may have one of the following annotations:
 	 * {@link DatabaseField}, {@link ForeignCollectionField}, or javax.persistence...
@@ -654,6 +663,7 @@ public class DatabaseFieldConfig {
 		config.version = databaseField.version();
 		config.foreignColumnName = valueIfNotBlank(databaseField.foreignColumnName());
 		config.readOnly = databaseField.readOnly();
+        config.since = databaseField.since();
 
 		return config;
 	}

--- a/src/main/java/com/j256/ormlite/field/DatabaseFieldConfigLoader.java
+++ b/src/main/java/com/j256/ormlite/field/DatabaseFieldConfigLoader.java
@@ -103,6 +103,7 @@ public class DatabaseFieldConfigLoader {
 	private static final String FIELD_NAME_VERSION = "version";
 	private static final String FIELD_NAME_FOREIGN_COLUMN_NAME = "foreignColumnName";
 	private static final String FIELD_NAME_READ_ONLY = "readOnly";
+	private static final String FIELD_NAME_SINCE = "since";
 
 	private static final String FIELD_NAME_FOREIGN_COLLECTION = "foreignCollection";
 	private static final String FIELD_NAME_FOREIGN_COLLECTION_EAGER = "foreignCollectionEager";
@@ -250,6 +251,10 @@ public class DatabaseFieldConfigLoader {
 			writer.append(FIELD_NAME_READ_ONLY).append('=').append("true");
 			writer.newLine();
 		}
+        if (config.getSince() != 0) {
+            writer.append(FIELD_NAME_SINCE).append('=').append(Integer.toString(config.getSince()));
+            writer.newLine();
+        }
 
 		/*
 		 * Foreign collection settings:
@@ -393,7 +398,9 @@ public class DatabaseFieldConfigLoader {
 			config.setForeignColumnName(value);
 		} else if (field.equals(FIELD_NAME_READ_ONLY)) {
 			config.setReadOnly(Boolean.parseBoolean(value));
-		}
+		} else if (field.equals(FIELD_NAME_SINCE)) {
+            config.setSince(Integer.parseInt(value));
+        }
 		/**
 		 * foreign collection field information
 		 */

--- a/src/main/java/com/j256/ormlite/field/FieldType.java
+++ b/src/main/java/com/j256/ormlite/field/FieldType.java
@@ -897,6 +897,13 @@ public class FieldType {
 		return fieldConfig.isReadOnly();
 	}
 
+    /**
+     * Call through to {@link DatabaseFieldConfig#getSince()}
+     */
+    public int getSince() {
+        return fieldConfig.getSince();
+    }
+
 	/**
 	 * Return the value of field in the data argument if it is not the default value for the class. If it is the default
 	 * then null is returned.

--- a/src/test/java/com/j256/ormlite/field/DatabaseFieldConfigLoaderTest.java
+++ b/src/test/java/com/j256/ormlite/field/DatabaseFieldConfigLoaderTest.java
@@ -182,6 +182,11 @@ public class DatabaseFieldConfigLoaderTest {
 		body.append("readOnly=true").append(LINE_SEP);
 		checkConfigOutput(config, body, writer, buffer);
 
+        int since = 13212;
+        config.setSince(since);
+        body.append("since=").append(since).append(LINE_SEP);
+        checkConfigOutput(config, body, writer, buffer);
+
 		/*
 		 * Test foreign collection
 		 */

--- a/src/test/java/com/j256/ormlite/field/DatabaseFieldConfigTest.java
+++ b/src/test/java/com/j256/ormlite/field/DatabaseFieldConfigTest.java
@@ -55,6 +55,11 @@ public class DatabaseFieldConfigTest extends BaseCoreTest {
 		config.setWidth(width);
 		assertEquals(width, config.getWidth());
 
+        assertEquals(0, config.getSince());
+        int since = 21312312;
+        config.setSince(since);
+        assertEquals(since, config.getSince());
+
 		assertFalse(config.isId());
 		config.setId(true);
 		assertTrue(config.isId());


### PR DESCRIPTION
An initial draft for implementing a 'since' property for a DatabaseField column.
This implementation attempts to prevent erroneous raw sql statements in the onUpgrade of Android. (or anywhere else)
Since is an integer representing the version number in which this DatabaseField was introduced.

Would appreciate feedback and your thoughts on such a feature in ORMLite.

Things I came across:
* Do we only use ADD COLUMN or also implement RENAME?
* How do we deal with INDEX / PRIMARY KEY / NULL / NOT NULL constraints?