### PR TITLE
Added UUID as a Specific SQL Type

### DIFF
--- a/src/main/java/com/j256/ormlite/db/BaseDatabaseType.java
+++ b/src/main/java/com/j256/ormlite/db/BaseDatabaseType.java
@@ -4,6 +4,8 @@ import java.sql.Driver;
 import java.sql.SQLException;
 import java.util.List;
 
+import org.apache.commons.lang.NotImplementedException;
+
 import com.j256.ormlite.field.BaseFieldConverter;
 import com.j256.ormlite.field.DataPersister;
 import com.j256.ormlite.field.FieldConverter;
@@ -120,7 +122,11 @@ public abstract class BaseDatabaseType implements DatabaseType {
 			case BIG_DECIMAL :
 				appendBigDecimalNumericType(sb, fieldType, fieldWidth);
 				break;
-
+			
+			case UUID:
+				appendUUIDType(sb, fieldType, fieldWidth);
+				break;
+				
 			case UNKNOWN :
 			default :
 				// shouldn't be able to get here unless we have a missing case
@@ -170,6 +176,13 @@ public abstract class BaseDatabaseType implements DatabaseType {
 		}
 	}
 
+	/**
+	 * Output the SQL type for a Java UUID.
+	 */
+	protected void appendUUIDType(StringBuilder sb, FieldType fieldType, int fieldWidth) {
+		throw new RuntimeException("UUID Is Database Specifc, Please Specify A Database Type");
+	}
+	
 	/**
 	 * Output the SQL type for a Java Long String.
 	 */

--- a/src/main/java/com/j256/ormlite/field/SqlType.java
+++ b/src/main/java/com/j256/ormlite/field/SqlType.java
@@ -27,6 +27,7 @@ public enum SqlType {
 	SERIALIZABLE,
 	BLOB,
 	BIG_DECIMAL,
+	UUID,
 	// for other types handled by custom persisters
 	OTHER,
 	UNKNOWN,

--- a/src/main/java/com/j256/ormlite/field/types/UuidType.java
+++ b/src/main/java/com/j256/ormlite/field/types/UuidType.java
@@ -24,7 +24,7 @@ public class UuidType extends BaseDataType {
 	}
 
 	private UuidType() {
-		super(SqlType.STRING, new Class<?>[] { UUID.class });
+		super(SqlType.UUID, new Class<?>[] { UUID.class });
 	}
 
 	/**


### PR DESCRIPTION
This is intended to use the UUID for PostgreSQL and UNIQUEIDENTIFIER for MSSQL as native sql datatypes. Please see the additional pull request in the jdbc as well.