### PR TITLE
Java 8 RuntimeExceptionDaoTest compliance.

### DIFF
--- a/src/test/java/com/j256/ormlite/dao/RuntimeExceptionDaoTest.java
+++ b/src/test/java/com/j256/ormlite/dao/RuntimeExceptionDaoTest.java
@@ -63,7 +63,7 @@ public class RuntimeExceptionDaoTest extends BaseCoreTest {
 			boolean found = false;
 
 			// coverage magic
-			if (daoMethod.getName().equals("$VRi")) {
+			if (daoMethod.getName().equals("$VRi") || daoMethod.getName().equals("spliterator") || daoMethod.getName().equals("forEach")) {
 				continue;
 			}
 


### PR DESCRIPTION
This pull request is to adapt RuntimeExceptionDaoTest to Java 8 ( see issue #30 ).