### PR TITLE
Pass SQLException#SQLState to next SQLException

### DIFF
--- a/src/main/java/com/j256/ormlite/misc/SqlExceptionUtil.java
+++ b/src/main/java/com/j256/ormlite/misc/SqlExceptionUtil.java
@@ -4,7 +4,7 @@ import java.sql.SQLException;
 
 /**
  * Utility class to help with SQLException throwing.
- * 
+ *
  * @author graywatson
  */
 public class SqlExceptionUtil {
@@ -19,7 +19,14 @@ public class SqlExceptionUtil {
 	 * Convenience method to allow a cause. Grrrr.
 	 */
 	public static SQLException create(String message, Throwable cause) {
-		SQLException sqlException = new SQLException(message);
+		SQLException sqlException;
+
+		if (cause instanceof SQLException) {
+			sqlException = new SQLException(message, ((SQLException) cause).getSQLState());
+		} else {
+			sqlException = new SQLException(message);
+		}
+
 		sqlException.initCause(cause);
 		return sqlException;
 	}

--- a/src/test/java/com/j256/ormlite/misc/SqlExceptionUtilTest.java
+++ b/src/test/java/com/j256/ormlite/misc/SqlExceptionUtilTest.java
@@ -19,6 +19,18 @@ public class SqlExceptionUtilTest {
 	}
 
 	@Test
+	public void testExceptionWithSQLException() {
+		String sqlReason = "sql exception message";
+		String sqlState = "sql exception state";
+		Throwable cause = new SQLException(sqlReason, sqlState);
+		String msg = "hello";
+		SQLException e = SqlExceptionUtil.create(msg, cause);
+		assertEquals(msg, e.getMessage());
+		assertEquals(sqlState, e.getSQLState());
+		assertEquals(cause, e.getCause());
+	}
+
+	@Test
 	public void testConstructor() throws Exception {
 		@SuppressWarnings({ "rawtypes" })
 		Constructor[] constructors = SqlExceptionUtil.class.getDeclaredConstructors();


### PR DESCRIPTION
The problem is that if you pass `SQLException` as a cause, user does not get the `SQLState` provided by the cause and has to check and cast type manually to obtain SQL error code. This may be quite tiresome and slightly hardens debugging.