### PR TITLE
Recursively apply order by and group by in joined queries

### DIFF
--- a/src/main/java/com/j256/ormlite/stmt/QueryBuilder.java
+++ b/src/main/java/com/j256/ormlite/stmt/QueryBuilder.java
@@ -758,11 +758,14 @@ public class QueryBuilder<T, ID> extends StatementBuilder<T, ID> {
 			databaseType.appendOffsetValue(sb, offset);
 		}
 	}
+    
+    private void appendGroupBys(StringBuilder sb){
+        appendGroupBys(sb, true);
+    }
 
-	private void appendGroupBys(StringBuilder sb) {
-		boolean first = true;
+	private boolean appendGroupBys(StringBuilder sb, boolean first) {
 		if (hasGroupStuff()) {
-			appendGroupBys(sb, first);
+			writeGroupBys(sb, first);
 			first = false;
 		}
 		/*
@@ -771,19 +774,19 @@ public class QueryBuilder<T, ID> extends StatementBuilder<T, ID> {
 		 */
 		if (joinList != null) {
 			for (JoinInfo joinInfo : joinList) {
-				if (joinInfo.queryBuilder != null && joinInfo.queryBuilder.hasGroupStuff()) {
-					joinInfo.queryBuilder.appendGroupBys(sb, first);
-					first = false;
+				if (joinInfo.queryBuilder != null) {
+					first = joinInfo.queryBuilder.appendGroupBys(sb, first);
 				}
 			}
 		}
+		return first;
 	}
 
 	private boolean hasGroupStuff() {
 		return (groupByList != null && !groupByList.isEmpty());
 	}
 
-	private void appendGroupBys(StringBuilder sb, boolean first) {
+	private void writeGroupBys(StringBuilder sb, boolean first) {
 		if (first) {
 			sb.append("GROUP BY ");
 		}
@@ -801,11 +804,14 @@ public class QueryBuilder<T, ID> extends StatementBuilder<T, ID> {
 		}
 		sb.append(' ');
 	}
+    
+    private void appendOrderBys(StringBuilder sb, List<ArgumentHolder> argList){
+        appendOrderBys(sb, true, argList);
+    }
 
-	private void appendOrderBys(StringBuilder sb, List<ArgumentHolder> argList) {
-		boolean first = true;
+	private boolean appendOrderBys(StringBuilder sb, boolean first, List<ArgumentHolder> argList) {
 		if (hasOrderStuff()) {
-			appendOrderBys(sb, first, argList);
+			writeOrderBys(sb, first, argList);
 			first = false;
 		}
 		/*
@@ -814,19 +820,19 @@ public class QueryBuilder<T, ID> extends StatementBuilder<T, ID> {
 		 */
 		if (joinList != null) {
 			for (JoinInfo joinInfo : joinList) {
-				if (joinInfo.queryBuilder != null && joinInfo.queryBuilder.hasOrderStuff()) {
-					joinInfo.queryBuilder.appendOrderBys(sb, first, argList);
-					first = false;
+				if (joinInfo.queryBuilder != null) {
+					first = joinInfo.queryBuilder.appendOrderBys(sb, first, argList);
 				}
 			}
 		}
+        return first;
 	}
 
 	private boolean hasOrderStuff() {
 		return (orderByList != null && !orderByList.isEmpty());
 	}
 
-	private void appendOrderBys(StringBuilder sb, boolean first, List<ArgumentHolder> argList) {
+	private void writeOrderBys(StringBuilder sb, boolean first, List<ArgumentHolder> argList) {
 		if (first) {
 			sb.append("ORDER BY ");
 		}


### PR DESCRIPTION
Currently if you have an order by or group by clause in a joined query it will be applied to the main query. However, if you join twice, and you nest the joins, as in this example:

```
QueryBuilder queryA = daoA.queryBuilder();
QueryBuilder queryB = daoB.queryBuilder();
QueryBuilder queryC = daoC.queryBuilder();
queryC.orderBy("column", true);
queryB.join(queryC);
queryA.join(queryB);
```

The outmost query will not be sorted by "column". Instead, the orderBy will be completely ignored.

This pull request is intended to fix that.
