### PR TITLE
Add getGenericType method to FieldType

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ target
 src/main/doc/ormlite.html
 src/main/doc/ormlite.pdf
 src/main/doc/ormlite
+.idea
+*.iml

--- a/src/main/java/com/j256/ormlite/field/FieldType.java
+++ b/src/main/java/com/j256/ormlite/field/FieldType.java
@@ -432,6 +432,13 @@ public class FieldType {
 		return field.getType();
 	}
 
+	/**
+	 * Return the generic type of the field associated with this field type.
+	 */
+	public Type getGenericType() {
+		return field.getGenericType();
+	}
+
 	public String getColumnName() {
 		return columnName;
 	}


### PR DESCRIPTION
This may be useful if the field is of some parametric type, like `List<String>`. The `Field::getType()` method which returns `Class<?>` won't contain the information about type parameters.