### PR TITLE
Javadocs weren't generated under Java 8.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@
 						</goals>
 						<configuration>
 							<showPackage>false</showPackage>
-							<additionalparam>-tag inheritDoc:X</additionalparam>
+							<additionalparam>-tag inheritDoc:X -Xdoclint:none</additionalparam>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
See for details: http://mail.openjdk.java.net/pipermail/build-infra-dev/2013-January/002899.html