### PR TITLE
Make Where.java constructor be protected

### DIFF
--- a/src/main/java/com/j256/ormlite/stmt/Where.java
+++ b/src/main/java/com/j256/ormlite/stmt/Where.java
@@ -110,7 +110,7 @@ public class Where<T, ID> {
 	private int clauseStackLevel;
 	private NeedsFutureClause needsFuture = null;
 
-	Where(TableInfo<T, ID> tableInfo, StatementBuilder<T, ID> statementBuilder, DatabaseType databaseType) {
+	protected Where(TableInfo<T, ID> tableInfo, StatementBuilder<T, ID> statementBuilder, DatabaseType databaseType) {
 		// limit the constructor scope
 		this.tableInfo = tableInfo;
 		this.statementBuilder = statementBuilder;


### PR DESCRIPTION
Allow Where to be extended, so that a sub class can perform validation on clauses.

Basically, I want to create a SafeWhere that wraps any String like Object in the eq and like methods in a SelectArg