### PR TITLE
Get table name from TableInfo

### DIFF
--- a/src/main/java/com/j256/ormlite/dao/BaseDaoImpl.java
+++ b/src/main/java/com/j256/ormlite/dao/BaseDaoImpl.java
@@ -1025,7 +1025,7 @@ public abstract class BaseDaoImpl<T, ID> implements Dao<T, ID> {
 
 	@Override
 	public String getTableName() {
-		return tableConfig.getTableName();
+		return tableInfo.getTableName();
 	}
 
 	/**

--- a/src/test/java/com/j256/ormlite/dao/BaseDaoImplTest.java
+++ b/src/test/java/com/j256/ormlite/dao/BaseDaoImplTest.java
@@ -2522,6 +2522,13 @@ public class BaseDaoImplTest extends BaseCoreTest {
 		assertEquals(foo2.stringField, foo.stringField);
 	}
 
+	@Test
+	public void testGetTableName() throws Exception {
+		Dao<Foo, Integer> dao = createDao(Foo.class, true);
+
+		assertEquals(FOO_TABLE_NAME, dao.getTableName());
+	}
+
 	/* ============================================================================================== */
 
 	private String buildFooQueryAllString(Dao<Foo, Object> fooDao) throws SQLException {


### PR DESCRIPTION
TableInfo is always populated, unlike TableConfig. Fixes issue #94.