### PR TITLE
Fix the problem with Turkish locale

### DIFF
--- a/src/main/java/com/j256/ormlite/table/DatabaseTableConfig.java
+++ b/src/main/java/com/j256/ormlite/table/DatabaseTableConfig.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Field;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import com.j256.ormlite.db.DatabaseType;
 import com.j256.ormlite.field.DatabaseField;
@@ -176,7 +177,7 @@ public class DatabaseTableConfig<T> {
 		}
 		if (name == null) {
 			// if the name isn't specified, it is the class name lowercased
-			name = clazz.getSimpleName().toLowerCase();
+			name = clazz.getSimpleName().toLowerCase(Locale.ENGLISH);
 		}
 		return name;
 	}

--- a/src/main/java/com/j256/ormlite/table/TableInfo.java
+++ b/src/main/java/com/j256/ormlite/table/TableInfo.java
@@ -3,6 +3,7 @@ package com.j256.ormlite.table;
 import java.lang.reflect.Constructor;
 import java.sql.SQLException;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import com.j256.ormlite.dao.BaseDaoImpl;
@@ -136,11 +137,11 @@ public class TableInfo<T, ID> {
 			// build our alias map if we need it
 			Map<String, FieldType> map = new HashMap<String, FieldType>();
 			for (FieldType fieldType : fieldTypes) {
-				map.put(fieldType.getColumnName().toLowerCase(), fieldType);
+				map.put(fieldType.getColumnName().toLowerCase(Locale.ENGLISH), fieldType);
 			}
 			fieldNameMap = map;
 		}
-		FieldType fieldType = fieldNameMap.get(columnName.toLowerCase());
+		FieldType fieldType = fieldNameMap.get(columnName.toLowerCase(Locale.ENGLISH));
 		// if column name is found, return it
 		if (fieldType != null) {
 			return fieldType;


### PR DESCRIPTION
From Java 7 javadocs:

> public String toLowerCase()
> Note: This method is locale sensitive, and may produce unexpected results if used for strings that are intended to be interpreted locale independently. Examples are programming language identifiers, protocol keys, and HTML tags. For instance, "TITLE".toLowerCase() in a Turkish locale returns "t\u0131tle", where '\u0131' is the LATIN SMALL LETTER DOTLESS I character. To obtain correct results for locale insensitive strings, use toLowerCase(Locale.ENGLISH). 

Fix for #87 #67 #108 