### PR TITLE
Add synchronized to createOrUpdate() and createIfNotExists() dao methods 

### DIFF
--- a/src/main/java/com/j256/ormlite/dao/BaseDaoImpl.java
+++ b/src/main/java/com/j256/ormlite/dao/BaseDaoImpl.java
@@ -363,7 +363,7 @@ public abstract class BaseDaoImpl<T, ID> implements Dao<T, ID> {
 	}
 
 	@Override
-	public T createIfNotExists(T data) throws SQLException {
+	public synchronized T createIfNotExists(T data) throws SQLException {
 		if (data == null) {
 			return null;
 		}
@@ -377,7 +377,7 @@ public abstract class BaseDaoImpl<T, ID> implements Dao<T, ID> {
 	}
 
 	@Override
-	public CreateOrUpdateStatus createOrUpdate(T data) throws SQLException {
+	public synchronized CreateOrUpdateStatus createOrUpdate(T data) throws SQLException {
 		if (data == null) {
 			return new CreateOrUpdateStatus(false, false, 0);
 		}

--- a/src/main/java/com/j256/ormlite/dao/Dao.java
+++ b/src/main/java/com/j256/ormlite/dao/Dao.java
@@ -177,6 +177,11 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	 * extracts the id from the data parameter, does a {@link #queryForId(Object)} on it, returning the data if it
 	 * exists. If it does not exist {@link #create(Object)} will be called with the parameter.
 	 * 
+	 * <p>
+	 * <b>NOTE:</b> This method is synchronized because otherwise race conditions would be encountered if this is used
+	 * by multiple threads.
+	 * </p>
+	 * 
 	 * @return Either the data parameter if it was inserted (now with the ID field set via the create method) or the
 	 *         data element that existed already in the database.
 	 */
@@ -188,6 +193,11 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	 * then all of the columns in the database will be updated from the fields in the data parameter. If the id is null
 	 * (or 0 or some other default value) or doesn't exist in the database then the object will be created in the
 	 * database. This also means that your data item <i>must</i> have an id field defined.
+	 * 
+	 * <p>
+	 * <b>NOTE:</b> This method is synchronized because otherwise race conditions would be encountered if this is used
+	 * by multiple threads.
+	 * </p>
 	 * 
 	 * @return Status object with the number of rows changed and whether an insert or update was performed.
 	 */

--- a/src/main/javadoc/doc-files/changelog.txt
+++ b/src/main/javadoc/doc-files/changelog.txt
@@ -1,4 +1,5 @@
 5.1: ?/??/2016
+	* CORE: Added synchronized keyword to BaseDaoImpl.createOrUpdate() and createIfNotExists().
 	* JDBC: Fixed problem with UUID native type not using the correct persister.  Thanks Bo98. 
 
 5.0: 6/27/2016


### PR DESCRIPTION
If multiple threads used createOrUpdate() or createIfNotExists(), race conditions could result.  Added synchronized keyword.