### PR TITLE
Add full column definition

### DIFF
--- a/src/main/doc/ormlite.texi
+++ b/src/main/doc/ormlite.texi
@@ -79,7 +79,7 @@ Gray Watson @uref{http://256.com/gray/}
 * How to Upgrade::              Upgrading from a previous version.
 * Examples::                    Usage examples to help you get started.
 * Contributions::               Contributions from others who helped.
-* License::                     Open Source license for the project.
+* License::                     ISC Open Source license for the project.
 * Index of Concepts::           Index of concepts in the manual.
 @end menu
 
@@ -2248,6 +2248,7 @@ public class Account @{
 @}
 @end example
 
+@cindex ForeignCollectionField annotation
 @anchor{ForeignCollectionField}
 In the above example, the @code{@@ForeignCollectionField} annotation marks that the @code{orders} field is a collection of the orders
 that match the account.  The field type of @code{orders} must be either @code{ForeignCollection<T>} or @code{Collection<T>} -- no
@@ -5276,9 +5277,10 @@ Thanks much to them all.
 
 @c ----------------------------------------------------------------
 @node License, Index of Concepts, Contributions, Top
-@chapter Open Source License
+@chapter ISC Open Source License
 
 @cindex license
+@cindex isc license
 @cindex open source license
 This document is part of the ORMLite project.
 
@@ -5291,7 +5293,7 @@ DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING F
 WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE
 USE OR PERFORMANCE OF THIS SOFTWARE.
 
-The author may be contacted via @uref{http://ormlite.com/}
+The author may be contacted via the @uref{http://ormlite.com/, ORMLite home page}.
 
 @c ----------------------------------------------------------------
 @node Index of Concepts,, License, Top

--- a/src/main/java/com/j256/ormlite/dao/BaseDaoImpl.java
+++ b/src/main/java/com/j256/ormlite/dao/BaseDaoImpl.java
@@ -148,8 +148,8 @@ public abstract class BaseDaoImpl<T, ID> implements Dao<T, ID> {
 
 		databaseType = connectionSource.getDatabaseType();
 		if (databaseType == null) {
-			throw new IllegalStateException("connectionSource is getting a null DatabaseType in "
-					+ getClass().getSimpleName());
+			throw new IllegalStateException(
+					"connectionSource is getting a null DatabaseType in " + getClass().getSimpleName());
 		}
 		if (tableConfig == null) {
 			tableInfo = new TableInfo<T, ID>(connectionSource, this, dataClass);
@@ -559,6 +559,7 @@ public abstract class BaseDaoImpl<T, ID> implements Dao<T, ID> {
 			public Iterator<T> iterator() {
 				return closeableIterator();
 			}
+
 			@Override
 			public CloseableIterator<T> closeableIterator() {
 				try {
@@ -578,6 +579,7 @@ public abstract class BaseDaoImpl<T, ID> implements Dao<T, ID> {
 			public Iterator<T> iterator() {
 				return closeableIterator();
 			}
+
 			@Override
 			public CloseableIterator<T> closeableIterator() {
 				try {
@@ -1083,7 +1085,7 @@ public abstract class BaseDaoImpl<T, ID> implements Dao<T, ID> {
 		throw new IllegalArgumentException("Could not find a field named " + fieldName);
 	}
 
-	CloseableIterator<T> createIterator(int resultFlags) {
+	private CloseableIterator<T> createIterator(int resultFlags) {
 		try {
 			SelectIterator<T, ID> iterator =
 					statementExecutor.buildIterator(this, connectionSource, resultFlags, objectCache);
@@ -1093,7 +1095,7 @@ public abstract class BaseDaoImpl<T, ID> implements Dao<T, ID> {
 		}
 	}
 
-	CloseableIterator<T> createIterator(PreparedQuery<T> preparedQuery, int resultFlags) throws SQLException {
+	private CloseableIterator<T> createIterator(PreparedQuery<T> preparedQuery, int resultFlags) throws SQLException {
 		try {
 			SelectIterator<T, ID> iterator =
 					statementExecutor.buildIterator(this, connectionSource, preparedQuery, objectCache, resultFlags);

--- a/src/main/java/com/j256/ormlite/field/DatabaseField.java
+++ b/src/main/java/com/j256/ormlite/field/DatabaseField.java
@@ -246,7 +246,8 @@ public @interface DatabaseField {
 
 	/**
 	 * Specify the SQL necessary to create this field in the database. This can be used if you need to tune the schema
-	 * to enable some per-database feature or to override the default SQL generated.
+	 * to enable some per-database feature or to override the default SQL generated. See {@link #fullColumnDefinition()}
+	 * .
 	 */
 	String columnDefinition() default "";
 
@@ -302,6 +303,15 @@ public @interface DatabaseField {
 	 * however it will be ignored during insert/create statements.
 	 */
 	boolean readOnly() default false;
+
+	/**
+	 * Specify the SQL necessary to create this field in the database including the column name, which should be
+	 * properly escaped and in proper case depending on your database type. This can be used if you need to fully
+	 * describe the schema to enable some per-database feature or to override the default SQL generated. The
+	 * {@link #columnDefinition()} should be used instead of this unless your database type needs to wrap the field name
+	 * somehow when defining the field.
+	 */
+	String fullColumnDefinition() default "";
 
 	/*
 	 * NOTE to developers: if you add fields here you have to add them to the DatabaseFieldConfig,

--- a/src/main/java/com/j256/ormlite/field/DatabaseFieldConfig.java
+++ b/src/main/java/com/j256/ormlite/field/DatabaseFieldConfig.java
@@ -69,6 +69,7 @@ public class DatabaseFieldConfig {
 	private String foreignCollectionOrderColumnName;
 	private boolean foreignCollectionOrderAscending = DEFAULT_FOREIGN_COLLECTION_ORDER_ASCENDING;
 	private String foreignCollectionForeignFieldName;
+	private String fullColumnDefinition;
 
 	static {
 		try {
@@ -93,9 +94,9 @@ public class DatabaseFieldConfig {
 
 	public DatabaseFieldConfig(String fieldName, String columnName, DataType dataType, String defaultValue, int width,
 			boolean canBeNull, boolean id, boolean generatedId, String generatedIdSequence, boolean foreign,
-			DatabaseTableConfig<?> foreignTableConfig, boolean useGetSet, Enum<?> unknownEnumValue,
-			boolean throwIfNull, String format, boolean unique, String indexName, String uniqueIndexName,
-			boolean autoRefresh, int maxForeignAutoRefreshLevel, int maxForeignCollectionLevel) {
+			DatabaseTableConfig<?> foreignTableConfig, boolean useGetSet, Enum<?> unknownEnumValue, boolean throwIfNull,
+			String format, boolean unique, String indexName, String uniqueIndexName, boolean autoRefresh,
+			int maxForeignAutoRefreshLevel, int maxForeignCollectionLevel) {
 		this.fieldName = fieldName;
 		this.columnName = columnName;
 		this.dataType = dataType;
@@ -464,6 +465,14 @@ public class DatabaseFieldConfig {
 		this.columnDefinition = columnDefinition;
 	}
 
+	public String getFullColumnDefinition() {
+		return fullColumnDefinition;
+	}
+
+	public void setFullColumnDefinition(String fullColumnDefinition) {
+		this.fullColumnDefinition = fullColumnDefinition;
+	}
+
 	public boolean isForeignAutoCreate() {
 		return foreignAutoCreate;
 	}
@@ -538,14 +547,12 @@ public class DatabaseFieldConfig {
 	public static Method findGetMethod(Field field, boolean throwExceptions) throws IllegalArgumentException {
 		Method fieldGetMethod;
 		if (Locale.ENGLISH.equals(Locale.getDefault())) {
-			fieldGetMethod =
-					findMethodFromNames(field, true, throwExceptions, methodFromField(field, "get", null),
-							methodFromField(field, "is", null));
+			fieldGetMethod = findMethodFromNames(field, true, throwExceptions, methodFromField(field, "get", null),
+					methodFromField(field, "is", null));
 		} else {
-			fieldGetMethod =
-					findMethodFromNames(field, true, throwExceptions, methodFromField(field, "get", null),
-							methodFromField(field, "get", Locale.ENGLISH), methodFromField(field, "is", null),
-							methodFromField(field, "is", Locale.ENGLISH));
+			fieldGetMethod = findMethodFromNames(field, true, throwExceptions, methodFromField(field, "get", null),
+					methodFromField(field, "get", Locale.ENGLISH), methodFromField(field, "is", null),
+					methodFromField(field, "is", Locale.ENGLISH));
 		}
 		if (fieldGetMethod == null) {
 			return null;
@@ -571,17 +578,16 @@ public class DatabaseFieldConfig {
 		if (Locale.ENGLISH.equals(Locale.getDefault())) {
 			fieldSetMethod = findMethodFromNames(field, false, throwExceptions, methodFromField(field, "set", null));
 		} else {
-			fieldSetMethod =
-					findMethodFromNames(field, false, throwExceptions, methodFromField(field, "set", null),
-							methodFromField(field, "set", Locale.ENGLISH));
+			fieldSetMethod = findMethodFromNames(field, false, throwExceptions, methodFromField(field, "set", null),
+					methodFromField(field, "set", Locale.ENGLISH));
 		}
 		if (fieldSetMethod == null) {
 			return null;
 		}
 		if (fieldSetMethod.getReturnType() != void.class) {
 			if (throwExceptions) {
-				throw new IllegalArgumentException("Return type of set method " + fieldSetMethod.getName()
-						+ " returns " + fieldSetMethod.getReturnType() + " instead of void");
+				throw new IllegalArgumentException("Return type of set method " + fieldSetMethod.getName() + " returns "
+						+ fieldSetMethod.getReturnType() + " instead of void");
 			} else {
 				return null;
 			}
@@ -635,6 +641,7 @@ public class DatabaseFieldConfig {
 		config.version = databaseField.version();
 		config.foreignColumnName = valueIfNotBlank(databaseField.foreignColumnName());
 		config.readOnly = databaseField.readOnly();
+		config.fullColumnDefinition = valueIfNotBlank(databaseField.fullColumnDefinition());
 
 		return config;
 	}
@@ -722,8 +729,9 @@ public class DatabaseFieldConfig {
 			}
 		}
 		if (throwExceptions) {
-			throw new IllegalArgumentException("Could not find appropriate " + (isGetMethod ? "get" : "set")
-					+ " method for " + field, firstException);
+			throw new IllegalArgumentException(
+					"Could not find appropriate " + (isGetMethod ? "get" : "set") + " method for " + field,
+					firstException);
 		} else {
 			return null;
 		}

--- a/src/main/java/com/j256/ormlite/field/DatabaseFieldConfigLoader.java
+++ b/src/main/java/com/j256/ormlite/field/DatabaseFieldConfigLoader.java
@@ -100,6 +100,7 @@ public class DatabaseFieldConfigLoader {
 	private static final String FIELD_NAME_PERSISTER_CLASS = "persisterClass";
 	private static final String FIELD_NAME_ALLOW_GENERATED_ID_INSERT = "allowGeneratedIdInsert";
 	private static final String FIELD_NAME_COLUMN_DEFINITION = "columnDefinition";
+	private static final String FIELD_NAME_FULL_COLUMN_DEFINITION = "fullColumnDefinition";
 	private static final String FIELD_NAME_FOREIGN_AUTO_CREATE = "foreignAutoCreate";
 	private static final String FIELD_NAME_VERSION = "version";
 	private static final String FIELD_NAME_FOREIGN_COLUMN_NAME = "foreignColumnName";
@@ -236,6 +237,10 @@ public class DatabaseFieldConfigLoader {
 		}
 		if (config.getColumnDefinition() != null) {
 			writer.append(FIELD_NAME_COLUMN_DEFINITION).append('=').append(config.getColumnDefinition());
+			writer.newLine();
+		}
+		if (config.getFullColumnDefinition() != null) {
+			writer.append(FIELD_NAME_FULL_COLUMN_DEFINITION).append('=').append(config.getFullColumnDefinition());
 			writer.newLine();
 		}
 		if (config.isForeignAutoCreate()) {
@@ -390,6 +395,8 @@ public class DatabaseFieldConfigLoader {
 			config.setAllowGeneratedIdInsert(Boolean.parseBoolean(value));
 		} else if (field.equals(FIELD_NAME_COLUMN_DEFINITION)) {
 			config.setColumnDefinition(value);
+		} else if (field.equals(FIELD_NAME_FULL_COLUMN_DEFINITION)) {
+			config.setFullColumnDefinition(value);
 		} else if (field.equals(FIELD_NAME_FOREIGN_AUTO_CREATE)) {
 			config.setForeignAutoCreate(Boolean.parseBoolean(value));
 		} else if (field.equals(FIELD_NAME_VERSION)) {

--- a/src/main/java/com/j256/ormlite/field/ForeignCollectionField.java
+++ b/src/main/java/com/j256/ormlite/field/ForeignCollectionField.java
@@ -81,8 +81,9 @@ public @interface ForeignCollectionField {
 
 	/**
 	 * Name of the _field_ (not the column name) in the class that the collection is holding that corresponds to the
-	 * collection. This is needed if there are two foreign fields in the class in the collection (such as a tree
-	 * structure) and you want to identify which column you want in this collection.
+	 * entity which holds the collection. This is needed if there are two foreign fields in the class in the collection
+	 * (such as a tree structure) and you want to identify which column identifies the "owner" of the foreign class.
+	 * This should be a field with the same type as the one which has the collection.
 	 * 
 	 * <p>
 	 * <b>WARNING:</b> Due to some internal complexities, this it field/member name in the class and _not_ the

--- a/src/main/javadoc/doc-files/changelog.txt
+++ b/src/main/javadoc/doc-files/changelog.txt
@@ -1,4 +1,5 @@
 5.1: ?/??/2016
+	* CORE: Added @DatabaseField(fullColumnDefinition) for fully describing a column as opposed to columnDefinition.
 	* JDBC: Fixed problem with UUID native type not using the correct persister.  Thanks Bo98. 
 
 5.0: 6/27/2016

--- a/src/test/java/com/j256/ormlite/field/DatabaseFieldConfigLoaderTest.java
+++ b/src/test/java/com/j256/ormlite/field/DatabaseFieldConfigLoaderTest.java
@@ -164,6 +164,11 @@ public class DatabaseFieldConfigLoaderTest extends BaseCoreTest {
 		body.append("columnDefinition=").append(columnDefinition).append(LINE_SEP);
 		checkConfigOutput(config, body, writer, buffer);
 
+		String fullColumnDefinition = "fullColumnDef";
+		config.setFullColumnDefinition(fullColumnDefinition);
+		body.append("fullColumnDefinition=").append(fullColumnDefinition).append(LINE_SEP);
+		checkConfigOutput(config, body, writer, buffer);
+
 		config.setForeignAutoCreate(false);
 		checkConfigOutput(config, body, writer, buffer);
 		config.setForeignAutoCreate(true);


### PR DESCRIPTION
In SQLite (maybe others) there are times when @DatabaseField(columnDefinition="...") isn't enough and the field name needs to be embedded in some special SQL.  Added a fullColumnDefinition that doesn't just append a definition string to the field name.