### PR TITLE
Added support for CloseableIterator.moveAbsolute(...)

### DIFF
--- a/src/main/java/com/j256/ormlite/dao/CloseableIterator.java
+++ b/src/main/java/com/j256/ormlite/dao/CloseableIterator.java
@@ -25,7 +25,8 @@ public interface CloseableIterator<T> extends Iterator<T>, Closeable {
 
 	/**
 	 * Return the underlying database results object if any. May return null. This should not be used unless you know
-	 * what you are doing.
+	 * what you are doing. For example, if you shift the cursor in the raw-results, this could cause problems when you
+	 * come back here to go the next result.
 	 */
 	public DatabaseResults getRawResults();
 
@@ -73,8 +74,10 @@ public interface CloseableIterator<T> extends Iterator<T>, Closeable {
 	public T moveRelative(int offset) throws SQLException;
 
 	/**
-	 * Move an absolute position in the list and return that result or null if none. This may not be supported depending
-	 * on your database.
+	 * Move to an absolute position in the list and return that result or null if none. This may not be supported
+	 * depending on your database or depending on the type of iterator and where you are moving. For example, in
+	 * JDBC-land, often the iterator created can only move forward and will throw an exception if you attempt to move to
+	 * an absolute position behind the current position.
 	 * 
 	 * @param position
 	 *            Row number in the result list to move to.

--- a/src/main/java/com/j256/ormlite/dao/CloseableIterator.java
+++ b/src/main/java/com/j256/ormlite/dao/CloseableIterator.java
@@ -68,6 +68,17 @@ public interface CloseableIterator<T> extends Iterator<T>, Closeable {
 	 * 
 	 * @param offset
 	 *            Number of rows to move. Positive moves forward in the results. Negative moves backwards.
+	 * @return The object at the new position or null of none.
 	 */
 	public T moveRelative(int offset) throws SQLException;
+
+	/**
+	 * Move an absolute position in the list and return that result or null if none. This may not be supported depending
+	 * on your database.
+	 * 
+	 * @param position
+	 *            Row number in the result list to move to.
+	 * @return The object at the new position or null of none.
+	 */
+	public T moveAbsolute(int position) throws SQLException;
 }

--- a/src/main/java/com/j256/ormlite/dao/EagerForeignCollection.java
+++ b/src/main/java/com/j256/ormlite/dao/EagerForeignCollection.java
@@ -17,8 +17,8 @@ import com.j256.ormlite.support.DatabaseResults;
  * 
  * @author graywatson
  */
-public class EagerForeignCollection<T, ID> extends BaseForeignCollection<T, ID> implements CloseableWrappedIterable<T>,
-		Serializable {
+public class EagerForeignCollection<T, ID> extends BaseForeignCollection<T, ID>
+		implements CloseableWrappedIterable<T>, Serializable {
 
 	private static final long serialVersionUID = -2523335606983317721L;
 
@@ -74,10 +74,12 @@ public class EagerForeignCollection<T, ID> extends BaseForeignCollection<T, ID> 
 		// we have to wrap the iterator since we are returning the List's iterator
 		return new CloseableIterator<T>() {
 			private int offset = -1;
+
 			@Override
 			public boolean hasNext() {
 				return (offset + 1 < results.size());
 			}
+
 			@Override
 			public T first() {
 				offset = 0;
@@ -87,12 +89,14 @@ public class EagerForeignCollection<T, ID> extends BaseForeignCollection<T, ID> 
 					return results.get(0);
 				}
 			}
+
 			@Override
 			public T next() {
 				offset++;
 				// this should throw if OOB
 				return results.get(offset);
 			}
+
 			@Override
 			public T nextThrow() {
 				offset++;
@@ -102,6 +106,7 @@ public class EagerForeignCollection<T, ID> extends BaseForeignCollection<T, ID> 
 					return results.get(offset);
 				}
 			}
+
 			@Override
 			public T current() {
 				if (offset < 0) {
@@ -113,6 +118,7 @@ public class EagerForeignCollection<T, ID> extends BaseForeignCollection<T, ID> 
 					return results.get(offset);
 				}
 			}
+
 			@Override
 			public T previous() {
 				offset--;
@@ -122,6 +128,7 @@ public class EagerForeignCollection<T, ID> extends BaseForeignCollection<T, ID> 
 					return results.get(offset);
 				}
 			}
+
 			@Override
 			public T moveRelative(int relativeOffset) {
 				offset += relativeOffset;
@@ -131,6 +138,17 @@ public class EagerForeignCollection<T, ID> extends BaseForeignCollection<T, ID> 
 					return results.get(offset);
 				}
 			}
+
+			@Override
+			public T moveAbsolute(int position) {
+				offset = position;
+				if (offset < 0 || offset >= results.size()) {
+					return null;
+				} else {
+					return results.get(offset);
+				}
+			}
+
 			@Override
 			public void remove() {
 				if (offset < 0) {
@@ -150,19 +168,23 @@ public class EagerForeignCollection<T, ID> extends BaseForeignCollection<T, ID> 
 					}
 				}
 			}
+
 			@Override
 			public void close() {
 				// noop
 			}
+
 			@Override
 			public void closeQuietly() {
 				// noop
 			}
+
 			@Override
 			public DatabaseResults getRawResults() {
 				// no results object
 				return null;
 			}
+
 			@Override
 			public void moveToNext() {
 				offset++;

--- a/src/main/java/com/j256/ormlite/stmt/SelectIterator.java
+++ b/src/main/java/com/j256/ormlite/stmt/SelectIterator.java
@@ -204,6 +204,19 @@ public class SelectIterator<T, ID> implements CloseableIterator<T> {
 		}
 	}
 
+	@Override
+	public T moveAbsolute(int position) throws SQLException {
+		if (closed) {
+			return null;
+		}
+		first = false;
+		if (results.moveAbsolute(position)) {
+			return getCurrent();
+		} else {
+			return null;
+		}
+	}
+
 	/**
 	 * Removes the last object returned by next() by calling delete on the dao associated with the object.
 	 * 

--- a/src/main/javadoc/doc-files/changelog.txt
+++ b/src/main/javadoc/doc-files/changelog.txt
@@ -2,6 +2,7 @@
 	* CORE: Added @DatabaseField(fullColumnDefinition) for fully describing a column as opposed to columnDefinition.
 	* CORE: Added synchronized keyword to BaseDaoImpl.createOrUpdate() and createIfNotExists().
 	* CORE: Added date integer date support.  Thanks to noordawod.
+	* CORE: Added support for CloseableIterator.moveAbsolute(...).  Thanks to renaudcerrato.
 	* CORE: Fixed but with get table name not using TableInfo.  Thanks to 0xabadea.
 	* CORE: Fixed handling of field capitalization which was screwing up Turkish fields.  Thanks to folkyatina.
 	* CORE: Fixed handling of joined queries with orders and group bys.  Thanks much to p91paul.


### PR DESCRIPTION
Not sure why `moveAbsolute(...)` was missing from this list since it is supported by the underlying `DatabaseResults`.