### PR TITLE
Fixed NPE if assigning null to a primitive type

### DIFF
--- a/src/main/java/com/j256/ormlite/field/FieldType.java
+++ b/src/main/java/com/j256/ormlite/field/FieldType.java
@@ -561,8 +561,12 @@ public class FieldType {
 			try {
 				field.set(data, val);
 			} catch (IllegalArgumentException e) {
-				throw SqlExceptionUtil.create(
-						"Could not assign object '" + val + "' of type " + val.getClass() + " to field " + this, e);
+				if (val == null) {
+					throw SqlExceptionUtil.create("Could not assign object '" + val + "' to field " + this, e);
+				} else {
+					throw SqlExceptionUtil.create(
+							"Could not assign object '" + val + "' of type " + val.getClass() + " to field " + this, e);
+				}
 			} catch (IllegalAccessException e) {
 				throw SqlExceptionUtil.create(
 						"Could not assign object '" + val + "' of type " + val.getClass() + "' to field " + this, e);

--- a/src/main/javadoc/doc-files/changelog.txt
+++ b/src/main/javadoc/doc-files/changelog.txt
@@ -1,3 +1,6 @@
+5.2: X/YY/2019
+	* CORE: Fixed problem with null field assignment causing a NPE in the resulting message.  Thanks to hrach.
+
 5.1: 2/19/2019
 	* CORE: Added @DatabaseField(fullColumnDefinition) for fully describing a column as opposed to columnDefinition.
 	* CORE: Added synchronized keyword to BaseDaoImpl.createOrUpdate() and createIfNotExists().

--- a/src/test/java/com/j256/ormlite/field/FieldTypeTest.java
+++ b/src/test/java/com/j256/ormlite/field/FieldTypeTest.java
@@ -343,8 +343,8 @@ public class FieldTypeTest extends BaseCoreTest {
 		assertEquals(id2, fieldType.extractJavaFieldToSqlArgValue(getSet));
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testFIeldSetNull() throws Exception {
+	@Test(expected = SQLException.class)
+	public void testFieldSetNull() throws Exception {
 		Field field = LocalFoo.class.getDeclaredField("intLong");
 		FieldType fieldType =
 				FieldType.createFieldType(connectionSource, LocalFoo.class.getSimpleName(), field, LocalFoo.class);

--- a/src/test/java/com/j256/ormlite/field/FieldTypeTest.java
+++ b/src/test/java/com/j256/ormlite/field/FieldTypeTest.java
@@ -343,6 +343,22 @@ public class FieldTypeTest extends BaseCoreTest {
 		assertEquals(id2, fieldType.extractJavaFieldToSqlArgValue(getSet));
 	}
 
+	@Test(expected = IllegalArgumentException.class)
+	public void testFIeldSetNull() throws Exception {
+		Field field = LocalFoo.class.getDeclaredField("intLong");
+		FieldType fieldType =
+				FieldType.createFieldType(connectionSource, LocalFoo.class.getSimpleName(), field, LocalFoo.class);
+		LocalFoo foo = new LocalFoo();
+		long value1 = 13413123123L;
+		foo.intLong = value1;
+		assertEquals(foo.intLong, fieldType.extractJavaFieldToSqlArgValue(foo));
+		long value2 = 5223423434L;
+		fieldType.assignField(foo, value2, false, null);
+		assertEquals(value2, foo.intLong);
+		// this should throw a illegal argument exception _not_ a NPE, thanks @hrach
+		fieldType.assignField(foo, null, false, null);
+	}
+
 	@Test(expected = SQLException.class)
 	public void testGetWrongObject() throws Exception {
 		Field[] fields = GetSet.class.getDeclaredFields();
@@ -798,8 +814,8 @@ public class FieldTypeTest extends BaseCoreTest {
 		foreignFieldConfigs.add(fieldConfig);
 
 		DatabaseTableConfig<ForeignObjectNoAnnotations> foreignTableConfig =
-				new DatabaseTableConfig<ForeignObjectNoAnnotations>(databaseType,
-						ForeignObjectNoAnnotations.class, foreignFieldConfigs);
+				new DatabaseTableConfig<ForeignObjectNoAnnotations>(databaseType, ForeignObjectNoAnnotations.class,
+						foreignFieldConfigs);
 		Dao<ForeignObjectNoAnnotations, Integer> foreignDao = createDao(foreignTableConfig, true);
 
 		ArrayList<DatabaseFieldConfig> parentFieldConfigs = new ArrayList<DatabaseFieldConfig>();
@@ -817,8 +833,9 @@ public class FieldTypeTest extends BaseCoreTest {
 		fieldConfig.setMaxForeignAutoRefreshLevel(2);
 		parentFieldConfigs.add(fieldConfig);
 
-		Dao<ObjectNoAnnotations, Integer> parentDao = createDao(
-				new DatabaseTableConfig<ObjectNoAnnotations>(databaseType, ObjectNoAnnotations.class, parentFieldConfigs), true);
+		Dao<ObjectNoAnnotations, Integer> parentDao =
+				createDao(new DatabaseTableConfig<ObjectNoAnnotations>(databaseType, ObjectNoAnnotations.class,
+						parentFieldConfigs), true);
 
 		ForeignObjectNoAnnotations foreign = new ForeignObjectNoAnnotations();
 		foreign.stuff = "hello";


### PR DESCRIPTION
Fixed problem with a field assigning that failed then causing a NPE because of a null pointer dereference.  Thanks to @hrach.