### PR TITLE
Allow retrieval of QueryBuilder from Where

### DIFF
--- a/src/main/java/com/j256/ormlite/stmt/Where.java
+++ b/src/main/java/com/j256/ormlite/stmt/Where.java
@@ -535,6 +535,19 @@ public class Where<T, ID> {
 		appendSql(null, sb, new ArrayList<ArgumentHolder>());
 		return sb.toString();
 	}
+		
+	/**
+	 * Returns the {@link QueryBuilder} used to create this Where, if present
+	 *
+	 * @returns the QueryBuilder object
+	 */
+	public QueryBuilder<T, ID> queryBuilder() throws SQLException {
+		if (statementBuilder instanceof QueryBuilder) {
+			return (QueryBuilder<T, ID>) statementBuilder;
+		} else {
+			throw new SQLException("Cannot cast " + statementBuilder.getType() + " to QueryBuilder");
+		}
+	}
 
 	/**
 	 * Used by the internal classes to add the where SQL to the {@link StringBuilder}.
@@ -566,19 +579,6 @@ public class Where<T, ID> {
 		} else {
 			Clause clause = peek();
 			return "where clause: " + clause;
-		}
-	}
-	
-	/**
-	 * Returns the {@link QueryBuilder} used to create this Where, if present
-	 *
-	 * @returns the QueryBuilder object
-	 */
-	public QueryBuilder<T, ID> queryBuilder() throws SQLException {
-		if (statementBuilder instanceof QueryBuilder) {
-			return (QueryBuilder<T, ID>) statementBuilder;
-		} else {
-			throw new SQLException("Cannot cast " + statementBuilder.getType() + " to QueryBuilder");
 		}
 	}
 

--- a/src/main/java/com/j256/ormlite/stmt/Where.java
+++ b/src/main/java/com/j256/ormlite/stmt/Where.java
@@ -568,6 +568,19 @@ public class Where<T, ID> {
 			return "where clause: " + clause;
 		}
 	}
+	
+	/**
+	 * Returns the {@link QueryBuilder} used to create this Where, if present
+	 *
+	 * @returns the QueryBuilder object
+	 */
+	public QueryBuilder<T, ID> queryBuilder() throws SQLException {
+		if (statementBuilder instanceof QueryBuilder) {
+			return (QueryBuilder<T, ID>) statementBuilder;
+		} else {
+			throw new SQLException("Cannot cast " + statementBuilder.getType() + " to QueryBuilder");
+		}
+	}
 
 	private QueryBuilder<T, ID> checkQueryBuilderMethod(String methodName) throws SQLException {
 		if (statementBuilder instanceof QueryBuilder) {


### PR DESCRIPTION
Allows building things like:
`dao.queryBuilder().leftjoin(dao2.queryBuilder().where().queryBuilder()).queryForFirst();`