### PR TITLE
Exposed BaseDatabaseType's int, float and double type string appenders to protected

### DIFF
--- a/src/main/java/com/j256/ormlite/db/BaseDatabaseType.java
+++ b/src/main/java/com/j256/ormlite/db/BaseDatabaseType.java
@@ -239,7 +239,7 @@ public abstract class BaseDatabaseType implements DatabaseType {
 	/**
 	 * Output the SQL type for a Java integer.
 	 */
-	private void appendIntegerType(StringBuilder sb, FieldType fieldType, int fieldWidth) {
+	protected void appendIntegerType(StringBuilder sb, FieldType fieldType, int fieldWidth) {
 		sb.append("INTEGER");
 	}
 
@@ -253,14 +253,14 @@ public abstract class BaseDatabaseType implements DatabaseType {
 	/**
 	 * Output the SQL type for a Java float.
 	 */
-	private void appendFloatType(StringBuilder sb, FieldType fieldType, int fieldWidth) {
+	protected void appendFloatType(StringBuilder sb, FieldType fieldType, int fieldWidth) {
 		sb.append("FLOAT");
 	}
 
 	/**
 	 * Output the SQL type for a Java double.
 	 */
-	private void appendDoubleType(StringBuilder sb, FieldType fieldType, int fieldWidth) {
+	protected void appendDoubleType(StringBuilder sb, FieldType fieldType, int fieldWidth) {
 		sb.append("DOUBLE PRECISION");
 	}
 


### PR DESCRIPTION
There's not too much reason for these to be the only ones that are private. While the need to override these methods will not be common, it does allow for the likes of example 1 in https://github.com/j256/ormlite-core/issues/20#issuecomment-443361114 to be possible.