### PR TITLE
Always clear special connection on batch tasks

### DIFF
--- a/src/main/java/com/j256/ormlite/stmt/StatementExecutor.java
+++ b/src/main/java/com/j256/ormlite/stmt/StatementExecutor.java
@@ -618,9 +618,7 @@ public class StatementExecutor<T, ID> implements GenericRowMapper<String[]> {
 			saved = connectionSource.saveSpecialConnection(connection);
 			return doCallBatchTasks(connection, saved, callable);
 		} finally {
-			if (saved) {
-				connectionSource.clearSpecialConnection(connection);
-			}
+			connectionSource.clearSpecialConnection(connection);
 			connectionSource.releaseConnection(connection);
 			localIsInBatchMode.set(false);
 			if (dao != null) {

--- a/src/test/java/com/j256/ormlite/stmt/StatementExecutorTest.java
+++ b/src/test/java/com/j256/ormlite/stmt/StatementExecutorTest.java
@@ -6,9 +6,11 @@ import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.concurrent.Callable;
@@ -17,12 +19,20 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Test;
 
 import com.j256.ormlite.dao.Dao;
+import com.j256.ormlite.dao.DaoManager;
+import com.j256.ormlite.db.DatabaseType;
 import com.j256.ormlite.field.DatabaseField;
+import com.j256.ormlite.h2.H2ConnectionSource;
+import com.j256.ormlite.logger.Logger;
+import com.j256.ormlite.logger.LoggerFactory;
+import com.j256.ormlite.misc.TransactionManager;
 import com.j256.ormlite.stmt.StatementBuilder.StatementType;
+import com.j256.ormlite.support.BaseConnectionSource;
 import com.j256.ormlite.support.CompiledStatement;
 import com.j256.ormlite.support.ConnectionSource;
 import com.j256.ormlite.support.DatabaseConnection;
 import com.j256.ormlite.table.TableInfo;
+import com.j256.ormlite.table.TableUtils;
 
 public class StatementExecutorTest extends BaseCoreStmtTest {
 
@@ -292,8 +302,105 @@ public class StatementExecutorTest extends BaseCoreStmtTest {
 		}
 	}
 
+	@Test
+	public void testCallBatchTasksNestedInTransaction() throws Exception {
+		SpecialConnectionSource cs = new SpecialConnectionSource(new H2ConnectionSource());
+		final Dao<Foo, Integer> dao = DaoManager.createDao(cs, Foo.class);
+		TableUtils.createTable(cs, Foo.class);
+		final Foo foo = new Foo();
+		assertEquals(1, dao.create(foo));
+
+		TransactionManager.callInTransaction(cs, new Callable<Void>() {
+			@Override
+			public Void call() throws Exception {
+				dao.callBatchTasks(new Callable<Void>() {
+					@Override
+					public Void call() throws Exception {
+						dao.delete(foo);
+						return null;
+					}
+				});
+				return null;
+			}
+		});
+
+		assertNull(dao.queryForId(foo.id));
+
+		assertNull(cs.getSpecialConnection(dao.getTableName()));
+	}
+
 	protected static class NoId {
 		@DatabaseField
 		String stuff;
+	}
+
+	private static class SpecialConnectionSource extends BaseConnectionSource {
+
+		private Logger logger = LoggerFactory.getLogger(getClass());
+		private ConnectionSource connectionSource;
+
+		SpecialConnectionSource(ConnectionSource connectionSource) {
+			this.connectionSource = connectionSource;
+		}
+
+		@Override
+		public DatabaseConnection getReadOnlyConnection(String tableName) throws SQLException {
+			DatabaseConnection conn = getSavedConnection();
+			if (conn == null) {
+				return connectionSource.getReadOnlyConnection(tableName);
+			} else {
+				return conn;
+			}
+		}
+
+		@Override
+		public DatabaseConnection getReadWriteConnection(String tableName) throws SQLException {
+			DatabaseConnection conn = getSavedConnection();
+			if (conn == null) {
+				return connectionSource.getReadWriteConnection(tableName);
+			} else {
+				return conn;
+			}
+		}
+
+		@Override
+		public void releaseConnection(DatabaseConnection connection) throws SQLException {
+			connectionSource.releaseConnection(connection);
+		}
+
+		@Override
+		public boolean saveSpecialConnection(DatabaseConnection connection) throws SQLException {
+			return saveSpecial(connection);
+		}
+
+		@Override
+		public void clearSpecialConnection(DatabaseConnection connection) {
+			clearSpecial(connection, logger);
+		}
+
+		@Override
+		public void closeQuietly() {
+			connectionSource.closeQuietly();
+		}
+
+		@Override
+		public DatabaseType getDatabaseType() {
+			return connectionSource.getDatabaseType();
+		}
+
+		@Override
+		public boolean isOpen(String tableName) {
+			return connectionSource.isOpen(tableName);
+		}
+
+		@Override
+		public boolean isSingleConnection(String tableName) {
+			return connectionSource.isSingleConnection(tableName);
+		}
+
+		@Override
+		public void close() throws IOException {
+			connectionSource.close();
+		}
 	}
 }

--- a/src/test/java/com/j256/ormlite/stmt/StatementExecutorTest.java
+++ b/src/test/java/com/j256/ormlite/stmt/StatementExecutorTest.java
@@ -79,6 +79,7 @@ public class StatementExecutorTest extends BaseCoreStmtTest {
 		expect(connectionSource.isSingleConnection("foo")).andReturn(false);
 		expect(connectionSource.getReadWriteConnection("foo")).andReturn(connection);
 		expect(connectionSource.saveSpecialConnection(connection)).andReturn(false);
+		connectionSource.clearSpecialConnection(connection);
 		connectionSource.releaseConnection(connection);
 
 		expect(connection.isAutoCommitSupported()).andReturn(false);
@@ -106,6 +107,7 @@ public class StatementExecutorTest extends BaseCoreStmtTest {
 		expect(connectionSource.isSingleConnection("foo")).andReturn(false);
 		expect(connectionSource.getReadWriteConnection("foo")).andReturn(connection);
 		expect(connectionSource.saveSpecialConnection(connection)).andReturn(false);
+		connectionSource.clearSpecialConnection(connection);
 		connectionSource.releaseConnection(connection);
 
 		expect(connection.isAutoCommitSupported()).andReturn(true);
@@ -134,6 +136,7 @@ public class StatementExecutorTest extends BaseCoreStmtTest {
 		expect(connectionSource.isSingleConnection("foo")).andReturn(false);
 		expect(connectionSource.getReadWriteConnection("foo")).andReturn(connection);
 		expect(connectionSource.saveSpecialConnection(connection)).andReturn(false);
+		connectionSource.clearSpecialConnection(connection);
 		connectionSource.releaseConnection(connection);
 
 		expect(connection.isAutoCommitSupported()).andReturn(true);
@@ -164,6 +167,7 @@ public class StatementExecutorTest extends BaseCoreStmtTest {
 		expect(connectionSource.isSingleConnection("foo")).andReturn(true);
 		expect(connectionSource.getReadWriteConnection("foo")).andReturn(connection);
 		expect(connectionSource.saveSpecialConnection(connection)).andReturn(false);
+		connectionSource.clearSpecialConnection(connection);
 		connectionSource.releaseConnection(connection);
 
 		expect(connection.isAutoCommitSupported()).andReturn(true);
@@ -194,6 +198,7 @@ public class StatementExecutorTest extends BaseCoreStmtTest {
 		expect(connectionSource.isSingleConnection("foo")).andReturn(false);
 		expect(connectionSource.getReadWriteConnection("foo")).andReturn(connection);
 		expect(connectionSource.saveSpecialConnection(connection)).andReturn(false);
+		connectionSource.clearSpecialConnection(connection);
 		connectionSource.releaseConnection(connection);
 
 		expect(connection.isAutoCommitSupported()).andReturn(true);


### PR DESCRIPTION
The [default behaviour](https://github.com/j256/ormlite-core/blob/e41f83a5a5ec8aec42ea6f30630ae0a8130a7c8f/src/main/java/com/j256/ormlite/support/BaseConnectionSource.java#L70) of `saveSpecialConnection` is to use a something similar to a reference counter. Unless I'm mistaken, that means that every call `saveSpecialConnection` _must_ later follow with a call to `clearSpecialConnection` _regardless_ of the return value of the former.