### PR TITLE
Support for java.time

### DIFF
--- a/src/main/java/com/j256/ormlite/db/BaseDatabaseType.java
+++ b/src/main/java/com/j256/ormlite/db/BaseDatabaseType.java
@@ -86,6 +86,26 @@ public abstract class BaseDatabaseType implements DatabaseType {
 				appendDateType(sb, fieldType, fieldWidth);
 				break;
 
+			case LOCAL_DATE:
+				appendLocalDateType(sb, fieldType, fieldWidth);
+				break;
+
+			case LOCAL_TIME:
+				appendLocalTimeType(sb, fieldType, fieldWidth);
+				break;
+
+			case LOCAL_DATE_TIME:
+				appendLocalDateTimeType(sb, fieldType, fieldWidth);
+				break;
+
+			case OFFSET_TIME:
+				appendOffsetTimeType(sb, fieldType, fieldWidth);
+				break;
+
+			case OFFSET_DATE_TIME:
+				appendOffsetDateTimeType(sb, fieldType, fieldWidth);
+				break;
+
 			case CHAR:
 				appendCharType(sb, fieldType, fieldWidth);
 				break;
@@ -206,6 +226,41 @@ public abstract class BaseDatabaseType implements DatabaseType {
 	 */
 	protected void appendDateType(StringBuilder sb, FieldType fieldType, int fieldWidth) {
 		sb.append("TIMESTAMP");
+	}
+
+	/**
+	 * Output the SQL type for a Java LocalDate.
+	 */
+	protected void appendLocalDateType(StringBuilder sb, FieldType fieldType, int fieldWidth) {
+		sb.append("DATE");
+	}
+
+	/**
+	 * Output the SQL type for a Java LocalTime.
+	 */
+	protected void appendLocalTimeType(StringBuilder sb, FieldType fieldType, int fieldWidth) {
+		sb.append("TIME");
+	}
+
+	/**
+	 * Output the SQL type for a Java LocalDateTime.
+	 */
+	protected void appendLocalDateTimeType(StringBuilder sb, FieldType fieldType, int fieldWidth) {
+		sb.append("TIMESTAMP");
+	}
+
+	/**
+	 * Output the SQL type for a Java OffsetTime.
+	 */
+	protected void appendOffsetTimeType(StringBuilder sb, FieldType fieldType, int fieldWidth) {
+		sb.append("TIME WITH TIME ZONE");
+	}
+
+	/**
+	 * Output the SQL type for a Java OffsetDateTime or Instant.
+	 */
+	protected void appendOffsetDateTimeType(StringBuilder sb, FieldType fieldType, int fieldWidth) {
+		sb.append("TIMESTAMP WITH TIME ZONE");
 	}
 
 	/**

--- a/src/main/java/com/j256/ormlite/field/DataType.java
+++ b/src/main/java/com/j256/ormlite/field/DataType.java
@@ -3,44 +3,7 @@ package com.j256.ormlite.field;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
-import com.j256.ormlite.field.types.BigDecimalNumericType;
-import com.j256.ormlite.field.types.BigDecimalStringType;
-import com.j256.ormlite.field.types.BigIntegerType;
-import com.j256.ormlite.field.types.BooleanCharType;
-import com.j256.ormlite.field.types.BooleanIntegerType;
-import com.j256.ormlite.field.types.BooleanObjectType;
-import com.j256.ormlite.field.types.BooleanType;
-import com.j256.ormlite.field.types.ByteArrayType;
-import com.j256.ormlite.field.types.ByteObjectType;
-import com.j256.ormlite.field.types.ByteType;
-import com.j256.ormlite.field.types.CharType;
-import com.j256.ormlite.field.types.CharacterObjectType;
-import com.j256.ormlite.field.types.DateLongType;
-import com.j256.ormlite.field.types.DateIntegerType;
-import com.j256.ormlite.field.types.DateStringType;
-import com.j256.ormlite.field.types.DateTimeType;
-import com.j256.ormlite.field.types.DateType;
-import com.j256.ormlite.field.types.DoubleObjectType;
-import com.j256.ormlite.field.types.DoubleType;
-import com.j256.ormlite.field.types.EnumIntegerType;
-import com.j256.ormlite.field.types.EnumStringType;
-import com.j256.ormlite.field.types.EnumToStringType;
-import com.j256.ormlite.field.types.FloatObjectType;
-import com.j256.ormlite.field.types.FloatType;
-import com.j256.ormlite.field.types.IntType;
-import com.j256.ormlite.field.types.IntegerObjectType;
-import com.j256.ormlite.field.types.LongObjectType;
-import com.j256.ormlite.field.types.LongStringType;
-import com.j256.ormlite.field.types.LongType;
-import com.j256.ormlite.field.types.NativeUuidType;
-import com.j256.ormlite.field.types.SerializableType;
-import com.j256.ormlite.field.types.ShortObjectType;
-import com.j256.ormlite.field.types.ShortType;
-import com.j256.ormlite.field.types.SqlDateType;
-import com.j256.ormlite.field.types.StringBytesType;
-import com.j256.ormlite.field.types.StringType;
-import com.j256.ormlite.field.types.TimeStampType;
-import com.j256.ormlite.field.types.UuidType;
+import com.j256.ormlite.field.types.*;
 
 /**
  * Data type enumeration that corresponds to a {@link DataPersister}.
@@ -249,6 +212,36 @@ public enum DataType {
 	 * Marker for fields that are unknown.
 	 */
 	UNKNOWN(null),
+	/**
+	 * Persists the {@link java.time.LocalDate} Java class.
+	 *
+	 */
+	LOCAL_DATE(LocalDateType.getSingleton()),
+	/**
+	 * Persists the {@link java.time.LocalTime} Java class.
+	 *
+	 */
+	LOCAL_TIME(LocalTimeType.getSingleton()),
+	/**
+	 * Persists the {@link java.time.LocalDateTime} Java class.
+	 *
+	 */
+	LOCAL_DATE_TIME(LocalDateTimeType.getSingleton()),
+	/**
+	 * Persists the {@link java.time.OffsetTime} Java class.
+	 *
+	 */
+	OFFSET_TIME(OffsetTimeType.getSingleton()),
+	/**
+	 * Persists the {@link java.time.OffsetDateTime} Java class.
+	 *
+	 */
+	OFFSET_DATE_TIME(OffsetDateTimeType.getSingleton()),
+	/**
+	 * Persists the {@link java.time.Instant} Java class.
+	 *
+	 */
+	INSTANT(InstantType.getSingleton()),
 	// end
 	;
 

--- a/src/main/java/com/j256/ormlite/field/DataType.java
+++ b/src/main/java/com/j256/ormlite/field/DataType.java
@@ -213,6 +213,30 @@ public enum DataType {
 	 */
 	UNKNOWN(null),
 	/**
+	 * Persists the {@link java.time.LocalDate} Java class. By default this will use
+	 * {@link #LOCAL_DATE} so you will need to specify this using {@link DatabaseField#dataType()}.
+	 *
+	 */
+	LOCAL_DATE_SQL(LocalDateSqlType.getSingleton()),
+	/**
+	 * Persists the {@link java.time.LocalTime} Java class. By default this will use
+	 * {@link #LOCAL_TIME} so you will need to specify this using {@link DatabaseField#dataType()}.
+	 *
+	 */
+	LOCAL_TIME_SQL(LocalTimeSqlType.getSingleton()),
+	/**
+	 * Persists the {@link java.time.LocalDateTime} Java class. By default this will use
+	 * {@link #LOCAL_DATE_TIME} so you will need to specify this using {@link DatabaseField#dataType()}.
+	 *
+	 */
+	LOCAL_DATE_TIME_SQL(LocalDateTimeSqlType.getSingleton()),
+	/**
+	 * Persists the {@link java.time.OffsetTime} Java class. By default this will use
+	 * {@link #OFFSET_TIME} so you will need to specify this using {@link DatabaseField#dataType()}.
+	 *
+	 */
+	OFFSET_TIME_SQL(OffsetTimeSqlType.getSingleton()),
+	/**
 	 * Persists the {@link java.time.LocalDate} Java class.
 	 *
 	 */

--- a/src/main/java/com/j256/ormlite/field/SqlType.java
+++ b/src/main/java/com/j256/ormlite/field/SqlType.java
@@ -32,6 +32,12 @@ public enum SqlType {
 	// for other types handled by custom persisters
 	OTHER,
 	UNKNOWN,
+	// java.time
+	LOCAL_DATE,
+	LOCAL_TIME,
+	LOCAL_DATE_TIME,
+	OFFSET_TIME,
+	OFFSET_DATE_TIME,
 	// end
 	;
 }

--- a/src/main/java/com/j256/ormlite/field/types/InstantType.java
+++ b/src/main/java/com/j256/ormlite/field/types/InstantType.java
@@ -1,0 +1,4 @@
+package com.j256.ormlite.field.types;
+
+public class InstantType {
+}

--- a/src/main/java/com/j256/ormlite/field/types/LocalDateSqlType.java
+++ b/src/main/java/com/j256/ormlite/field/types/LocalDateSqlType.java
@@ -33,7 +33,7 @@ public class LocalDateSqlType extends BaseDataType {
     @Override
     public Object parseDefaultString(FieldType fieldType, String defaultStr) throws SQLException {
         try {
-            return LocalDate.parse(defaultStr, DateTimeFormatter.ISO_LOCAL_DATE);
+            return Date.valueOf(LocalDate.parse(defaultStr, DateTimeFormatter.ISO_LOCAL_DATE));
         } catch (NumberFormatException e) {
             throw SqlExceptionUtil.create("Problems with field " + fieldType +
                     " parsing default LocalDate value: " + defaultStr, e);
@@ -42,19 +42,19 @@ public class LocalDateSqlType extends BaseDataType {
 
     @Override
     public Object resultToSqlArg(FieldType fieldType, DatabaseResults results, int columnPos) throws SQLException {
-        return results.getDate(columnPos).toLocalDate();
-    }
-
-    @Override
-    public Object sqlArgToJava(FieldType fieldType, Object sqlArg, int columnPos) {
-        Date value = (Date) sqlArg;
-        return value.toLocalDate();
+        return results.getDate(columnPos);
     }
 
     @Override
     public Object javaToSqlArg(FieldType fieldType, Object javaObject) {
         LocalDate date = (LocalDate) javaObject;
         return Date.valueOf(date);
+    }
+
+    @Override
+    public Object sqlArgToJava(FieldType fieldType, Object sqlArg, int columnPos) {
+        Date date = (Date) sqlArg;
+        return date.toLocalDate();
     }
 
     @Override

--- a/src/main/java/com/j256/ormlite/field/types/LocalDateSqlType.java
+++ b/src/main/java/com/j256/ormlite/field/types/LocalDateSqlType.java
@@ -1,10 +1,9 @@
 package com.j256.ormlite.field.types;
 
 import java.lang.reflect.Field;
+import java.sql.Date;
 import java.sql.SQLException;
-import java.time.Instant;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
+import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
 import com.j256.ormlite.field.FieldType;
@@ -17,44 +16,45 @@ import com.j256.ormlite.support.DatabaseResults;
  *
  * @author graynk
  */
-public class InstantType extends BaseDataType {
+public class LocalDateSqlType extends BaseDataType {
 
-    private static final InstantType singleton = new InstantType();
-    public static InstantType getSingleton() {
+    private static final LocalDateSqlType singleton = new LocalDateSqlType();
+    public static LocalDateSqlType getSingleton() {
         try {
-            Class.forName("java.time.Instant", false, null);
+            Class.forName("java.time.LocalDate", false, null);
         } catch (ClassNotFoundException e) {
             return null; // No java.time on classpath;
         }
-        return singleton; }
-    private InstantType() { super(SqlType.OFFSET_DATE_TIME, new Class<?>[] { Instant.class }); }
-    protected InstantType(SqlType sqlType, Class<?>[] classes) { super(sqlType, classes); }
+        return singleton;
+    }
+    private LocalDateSqlType() { super(SqlType.LOCAL_DATE, new Class<?>[] { LocalDate.class }); }
+    protected LocalDateSqlType(SqlType sqlType, Class<?>[] classes) { super(sqlType, classes); }
 
     @Override
     public Object parseDefaultString(FieldType fieldType, String defaultStr) throws SQLException {
         try {
-            return OffsetDateTime.parse(defaultStr, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.Sx")).toInstant();
+            return LocalDate.parse(defaultStr, DateTimeFormatter.ISO_LOCAL_DATE);
         } catch (NumberFormatException e) {
             throw SqlExceptionUtil.create("Problems with field " + fieldType +
-                    " parsing default LocalDateTime value: " + defaultStr, e);
+                    " parsing default LocalDate value: " + defaultStr, e);
         }
     }
 
     @Override
     public Object resultToSqlArg(FieldType fieldType, DatabaseResults results, int columnPos) throws SQLException {
-        return results.getOffsetDateTime(columnPos);
+        return results.getDate(columnPos).toLocalDate();
     }
 
     @Override
     public Object sqlArgToJava(FieldType fieldType, Object sqlArg, int columnPos) {
-        OffsetDateTime value = (OffsetDateTime) sqlArg;
-        return value.toInstant();
+        Date value = (Date) sqlArg;
+        return value.toLocalDate();
     }
 
     @Override
     public Object javaToSqlArg(FieldType fieldType, Object javaObject) {
-        Instant instant = (Instant) javaObject;
-        return OffsetDateTime.ofInstant(instant, ZoneOffset.UTC);
+        LocalDate date = (LocalDate) javaObject;
+        return Date.valueOf(date);
     }
 
     @Override
@@ -64,17 +64,17 @@ public class InstantType extends BaseDataType {
 
     @Override
     public Object moveToNextValue(Object currentValue) {
-        Instant datetime = (Instant) currentValue;
-        return datetime.plusNanos(1);
-    }
-
-    @Override
-    public boolean isValidForField(Field field) {
-        return (field.getType() == Instant.class);
+        LocalDate date = (LocalDate) currentValue;
+        return date.plusDays(1);
     }
 
     @Override
     public boolean isArgumentHolderRequired() {
         return true;
+    }
+
+    @Override
+    public boolean isValidForField(Field field) {
+        return (field.getType() == LocalDate.class);
     }
 }

--- a/src/main/java/com/j256/ormlite/field/types/LocalDateTimeSqlType.java
+++ b/src/main/java/com/j256/ormlite/field/types/LocalDateTimeSqlType.java
@@ -33,7 +33,7 @@ public class LocalDateTimeSqlType extends BaseDataType {
     @Override
     public Object parseDefaultString(FieldType fieldType, String defaultStr) throws SQLException {
         try {
-            return LocalDateTime.parse(defaultStr, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS"));
+            return Timestamp.valueOf(LocalDateTime.parse(defaultStr, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss[.SSS]")));
         } catch (NumberFormatException e) {
             throw SqlExceptionUtil.create("Problems with field " + fieldType +
                     " parsing default LocalDateTime value: " + defaultStr, e);
@@ -42,7 +42,7 @@ public class LocalDateTimeSqlType extends BaseDataType {
 
     @Override
     public Object resultToSqlArg(FieldType fieldType, DatabaseResults results, int columnPos) throws SQLException {
-        return results.getTimestamp(columnPos).toLocalDateTime();
+        return results.getTimestamp(columnPos);
     }
 
     @Override

--- a/src/main/java/com/j256/ormlite/field/types/LocalDateTimeSqlType.java
+++ b/src/main/java/com/j256/ormlite/field/types/LocalDateTimeSqlType.java
@@ -2,9 +2,8 @@ package com.j256.ormlite.field.types;
 
 import java.lang.reflect.Field;
 import java.sql.SQLException;
-import java.time.Instant;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 import com.j256.ormlite.field.FieldType;
@@ -13,27 +12,28 @@ import com.j256.ormlite.misc.SqlExceptionUtil;
 import com.j256.ormlite.support.DatabaseResults;
 
 /**
- * A custom persister that is able to store the java.time.LocalDate class in the database as Date object.
+ * A custom persister that is able to store the java.time.LocalDateTime class in the database as Timestamp object.
  *
  * @author graynk
  */
-public class InstantType extends BaseDataType {
+public class LocalDateTimeSqlType extends BaseDataType {
 
-    private static final InstantType singleton = new InstantType();
-    public static InstantType getSingleton() {
+    private static final LocalDateTimeSqlType singleton = new LocalDateTimeSqlType();
+    public static LocalDateTimeSqlType getSingleton() {
         try {
-            Class.forName("java.time.Instant", false, null);
+            Class.forName("java.time.LocalDateTime", false, null);
         } catch (ClassNotFoundException e) {
             return null; // No java.time on classpath;
         }
-        return singleton; }
-    private InstantType() { super(SqlType.OFFSET_DATE_TIME, new Class<?>[] { Instant.class }); }
-    protected InstantType(SqlType sqlType, Class<?>[] classes) { super(sqlType, classes); }
+        return singleton;
+    }
+    private LocalDateTimeSqlType() { super(SqlType.DATE, new Class<?>[] { LocalDateTime.class }); }
+    protected LocalDateTimeSqlType(SqlType sqlType, Class<?>[] classes) { super(sqlType, classes); }
 
     @Override
     public Object parseDefaultString(FieldType fieldType, String defaultStr) throws SQLException {
         try {
-            return OffsetDateTime.parse(defaultStr, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.Sx")).toInstant();
+            return LocalDateTime.parse(defaultStr, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS"));
         } catch (NumberFormatException e) {
             throw SqlExceptionUtil.create("Problems with field " + fieldType +
                     " parsing default LocalDateTime value: " + defaultStr, e);
@@ -42,19 +42,19 @@ public class InstantType extends BaseDataType {
 
     @Override
     public Object resultToSqlArg(FieldType fieldType, DatabaseResults results, int columnPos) throws SQLException {
-        return results.getOffsetDateTime(columnPos);
+        return results.getTimestamp(columnPos).toLocalDateTime();
     }
 
     @Override
     public Object sqlArgToJava(FieldType fieldType, Object sqlArg, int columnPos) {
-        OffsetDateTime value = (OffsetDateTime) sqlArg;
-        return value.toInstant();
+        Timestamp value = (Timestamp) sqlArg;
+        return value.toLocalDateTime();
     }
 
     @Override
     public Object javaToSqlArg(FieldType fieldType, Object javaObject) {
-        Instant instant = (Instant) javaObject;
-        return OffsetDateTime.ofInstant(instant, ZoneOffset.UTC);
+        LocalDateTime datetime = (LocalDateTime) javaObject;
+        return Timestamp.valueOf(datetime);
     }
 
     @Override
@@ -64,17 +64,17 @@ public class InstantType extends BaseDataType {
 
     @Override
     public Object moveToNextValue(Object currentValue) {
-        Instant datetime = (Instant) currentValue;
-        return datetime.plusNanos(1);
-    }
-
-    @Override
-    public boolean isValidForField(Field field) {
-        return (field.getType() == Instant.class);
+        LocalDateTime date = (LocalDateTime) currentValue;
+        return date.plusNanos(1);
     }
 
     @Override
     public boolean isArgumentHolderRequired() {
         return true;
+    }
+
+    @Override
+    public boolean isValidForField(Field field) {
+        return (field.getType() == LocalDateTime.class);
     }
 }

--- a/src/main/java/com/j256/ormlite/field/types/LocalDateTimeType.java
+++ b/src/main/java/com/j256/ormlite/field/types/LocalDateTimeType.java
@@ -32,7 +32,7 @@ public class LocalDateTimeType extends BaseDataType {
     @Override
     public Object parseDefaultString(FieldType fieldType, String defaultStr) throws SQLException {
         try {
-            return LocalDateTime.parse(defaultStr, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS"));
+            return LocalDateTime.parse(defaultStr, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss[.SSS]"));
         } catch (NumberFormatException e) {
             throw SqlExceptionUtil.create("Problems with field " + fieldType +
                     " parsing default LocalDateTime value: " + defaultStr, e);

--- a/src/main/java/com/j256/ormlite/field/types/LocalDateTimeType.java
+++ b/src/main/java/com/j256/ormlite/field/types/LocalDateTimeType.java
@@ -1,4 +1,67 @@
 package com.j256.ormlite.field.types;
 
-public class LocalDateTimeType {
+import java.lang.reflect.Field;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.field.SqlType;
+import com.j256.ormlite.misc.SqlExceptionUtil;
+import com.j256.ormlite.support.DatabaseResults;
+
+/**
+ * A custom persister that is able to store the java.time.LocalDate class in the database as Date object.
+ *
+ * @author graynk
+ */
+public class LocalDateTimeType extends BaseDataType {
+
+    private static final LocalDateTimeType singleton = new LocalDateTimeType();
+    public static LocalDateTimeType getSingleton() {
+        try {
+            Class.forName("java.time.LocalDateTime", false, null);
+        } catch (ClassNotFoundException e) {
+            return null; // No java.time on classpath;
+        }
+        return singleton;
+    }
+    private LocalDateTimeType() { super(SqlType.LOCAL_DATE_TIME, new Class<?>[] { LocalDateTime.class }); }
+    protected LocalDateTimeType(SqlType sqlType, Class<?>[] classes) { super(sqlType, classes); }
+
+    @Override
+    public Object parseDefaultString(FieldType fieldType, String defaultStr) throws SQLException {
+        try {
+            return LocalDateTime.parse(defaultStr, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS"));
+        } catch (NumberFormatException e) {
+            throw SqlExceptionUtil.create("Problems with field " + fieldType +
+                    " parsing default LocalDateTime value: " + defaultStr, e);
+        }
+    }
+
+    @Override
+    public Object resultToSqlArg(FieldType fieldType, DatabaseResults results, int columnPos) throws SQLException {
+        return results.getLocalDateTime(columnPos);
+    }
+
+    @Override
+    public boolean isValidForVersion() {
+        return true;
+    }
+
+    @Override
+    public Object moveToNextValue(Object currentValue) {
+        LocalDateTime datetime = (LocalDateTime) currentValue;
+        return datetime.plusNanos(1);
+    }
+
+    @Override
+    public boolean isValidForField(Field field) {
+        return (field.getType() == LocalDateTime.class);
+    }
+
+    @Override
+    public boolean isArgumentHolderRequired() {
+        return true;
+    }
 }

--- a/src/main/java/com/j256/ormlite/field/types/LocalDateTimeType.java
+++ b/src/main/java/com/j256/ormlite/field/types/LocalDateTimeType.java
@@ -1,0 +1,4 @@
+package com.j256.ormlite.field.types;
+
+public class LocalDateTimeType {
+}

--- a/src/main/java/com/j256/ormlite/field/types/LocalDateType.java
+++ b/src/main/java/com/j256/ormlite/field/types/LocalDateType.java
@@ -1,0 +1,123 @@
+package com.j256.ormlite.field.types;
+
+import java.sql.SQLException;
+
+import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.field.SqlType;
+import com.j256.ormlite.misc.SqlExceptionUtil;
+import com.j256.ormlite.support.DatabaseResults;
+
+/**
+ * A custom persister that is able to store the java.time.LocalDateTime class in the database as Date object.
+ *
+ * @author graynk
+ */
+public class LocalDateTimeType extends BaseDataType {
+
+    private static final LocalDateTimeType singleton = new LocalDateTimeType();
+    public static LocalDateTimeType getSingleton() { return singleton; }
+    private LocalDateTimeType() { super(SqlType.LONG); }
+
+    protected LocalDateTimeType(SqlType sqlType, Class<?>[] classes) {
+        super(sqlType, classes);
+    }
+
+    @Override
+    public Object javaToSqlArg(FieldType fieldType, Object javaObject) throws SQLException {
+        return extractMillis(javaObject);
+    }
+
+    @Override
+    public Object parseDefaultString(FieldType fieldType, String defaultStr) throws SQLException {
+        try {
+            return Long.parseLong(defaultStr);
+        } catch (NumberFormatException e) {
+            throw SqlExceptionUtil.create("Problems with field " + fieldType + " parsing default DateTime value: "
+                    + defaultStr, e);
+        }
+    }
+
+    @Override
+    public Object resultToSqlArg(FieldType fieldType, DatabaseResults results, int columnPos) throws SQLException {
+        return results.getLong(columnPos);
+    }
+
+    @Override
+    public Object sqlArgToJava(FieldType fieldType, Object sqlArg, int columnPos) throws SQLException {
+        return createInstance((Long) sqlArg);
+    }
+
+    @Override
+    public boolean isEscapedValue() {
+        return false;
+    }
+
+    @Override
+    public boolean isAppropriateId() {
+        return false;
+    }
+
+    @Override
+    public Class<?> getPrimaryClass() {
+        try {
+            return getDateTimeClass();
+        } catch (ClassNotFoundException e) {
+            // ignore the exception
+            return null;
+        }
+    }
+
+    @Override
+    public boolean isValidForVersion() {
+        return true;
+    }
+
+    @Override
+    public Object moveToNextValue(Object currentValue) throws SQLException {
+        long newVal = System.currentTimeMillis();
+        if (currentValue == null) {
+            return createInstance(newVal);
+        }
+        Long currentVal = extractMillis(currentValue);
+        if (newVal == currentVal) {
+            return createInstance(newVal + 1L);
+        } else {
+            return createInstance(newVal);
+        }
+    }
+
+    private Object createInstance(Long sqlArg) throws SQLException {
+        try {
+            if (millisConstructor == null) {
+                Class<?> clazz = getDateTimeClass();
+                millisConstructor = clazz.getConstructor(long.class);
+            }
+            return millisConstructor.newInstance(sqlArg);
+        } catch (Exception e) {
+            throw SqlExceptionUtil.create("Could not use reflection to construct a Joda DateTime", e);
+        }
+    }
+
+    private Long extractMillis(Object javaObject) throws SQLException {
+        try {
+            if (getMillisMethod == null) {
+                Class<?> clazz = getDateTimeClass();
+                getMillisMethod = clazz.getMethod("getMillis");
+            }
+            if (javaObject == null) {
+                return null;
+            } else {
+                return (Long) getMillisMethod.invoke(javaObject);
+            }
+        } catch (Exception e) {
+            throw SqlExceptionUtil.create("Could not use reflection to get millis from Joda DateTime: " + javaObject, e);
+        }
+    }
+
+    private Class<?> getDateTimeClass() throws ClassNotFoundException {
+        if (dateTimeClass == null) {
+            dateTimeClass = Class.forName("org.joda.time.DateTime");
+        }
+        return dateTimeClass;
+    }
+}

--- a/src/main/java/com/j256/ormlite/field/types/LocalTimeSqlType.java
+++ b/src/main/java/com/j256/ormlite/field/types/LocalTimeSqlType.java
@@ -1,0 +1,80 @@
+package com.j256.ormlite.field.types;
+
+import java.lang.reflect.Field;
+import java.sql.SQLException;
+import java.sql.Time;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.field.SqlType;
+import com.j256.ormlite.misc.SqlExceptionUtil;
+import com.j256.ormlite.support.DatabaseResults;
+
+/**
+ * A custom persister that is able to store the java.time.LocalTime class in the database as Time object.
+ *
+ * @author graynk
+ */
+public class LocalTimeSqlType extends BaseDataType {
+
+    private static final LocalTimeSqlType singleton = new LocalTimeSqlType();
+    public static LocalTimeSqlType getSingleton() {
+        try {
+            Class.forName("java.time.LocalTime", false, null);
+        } catch (ClassNotFoundException e) {
+            return null; // No java.time on classpath;
+        }
+        return singleton;
+    }
+    private LocalTimeSqlType() { super(SqlType.LOCAL_TIME, new Class<?>[] { LocalTime.class }); }
+    protected LocalTimeSqlType(SqlType sqlType, Class<?>[] classes) { super(sqlType, classes); }
+
+    @Override
+    public Object parseDefaultString(FieldType fieldType, String defaultStr) throws SQLException {
+        try {
+            return LocalTime.parse(defaultStr, DateTimeFormatter.ofPattern("HH:mm:ss.SSSSSS"));
+        } catch (NumberFormatException e) {
+            throw SqlExceptionUtil.create("Problems with field " + fieldType +
+                    " parsing default LocalTime value: " + defaultStr, e);
+        }
+    }
+
+    @Override
+    public Object resultToSqlArg(FieldType fieldType, DatabaseResults results, int columnPos) throws SQLException {
+        return results.getTime(columnPos).toLocalTime();
+    }
+
+    @Override
+    public Object sqlArgToJava(FieldType fieldType, Object sqlArg, int columnPos) {
+        Time value = (Time) sqlArg;
+        return value.toLocalTime();
+    }
+
+    @Override
+    public Object javaToSqlArg(FieldType fieldType, Object javaObject) {
+        LocalTime time = (LocalTime) javaObject;
+        return Time.valueOf(time);
+    }
+
+    @Override
+    public boolean isValidForVersion() {
+        return true;
+    }
+
+    @Override
+    public Object moveToNextValue(Object currentValue) {
+        LocalTime time = (LocalTime) currentValue;
+        return time.plusNanos(1);
+    }
+
+    @Override
+    public boolean isArgumentHolderRequired() {
+        return true;
+    }
+
+    @Override
+    public boolean isValidForField(Field field) {
+        return (field.getType() == LocalTime.class);
+    }
+}

--- a/src/main/java/com/j256/ormlite/field/types/LocalTimeSqlType.java
+++ b/src/main/java/com/j256/ormlite/field/types/LocalTimeSqlType.java
@@ -33,7 +33,7 @@ public class LocalTimeSqlType extends BaseDataType {
     @Override
     public Object parseDefaultString(FieldType fieldType, String defaultStr) throws SQLException {
         try {
-            return LocalTime.parse(defaultStr, DateTimeFormatter.ofPattern("HH:mm:ss.SSSSSS"));
+            return Time.valueOf(LocalTime.parse(defaultStr, DateTimeFormatter.ofPattern("HH:mm:ss[.SSSSSS]")));
         } catch (NumberFormatException e) {
             throw SqlExceptionUtil.create("Problems with field " + fieldType +
                     " parsing default LocalTime value: " + defaultStr, e);
@@ -42,7 +42,7 @@ public class LocalTimeSqlType extends BaseDataType {
 
     @Override
     public Object resultToSqlArg(FieldType fieldType, DatabaseResults results, int columnPos) throws SQLException {
-        return results.getTime(columnPos).toLocalTime();
+        return results.getTime(columnPos);
     }
 
     @Override

--- a/src/main/java/com/j256/ormlite/field/types/LocalTimeType.java
+++ b/src/main/java/com/j256/ormlite/field/types/LocalTimeType.java
@@ -1,4 +1,66 @@
 package com.j256.ormlite.field.types;
 
-public class LocalTimeType {
+import java.lang.reflect.Field;
+import java.sql.SQLException;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.field.SqlType;
+import com.j256.ormlite.misc.SqlExceptionUtil;
+import com.j256.ormlite.support.DatabaseResults;
+
+/**
+ * A custom persister that is able to store the java.time.LocalDate class in the database as Date object.
+ *
+ * @author graynk
+ */
+public class LocalTimeType extends BaseDataType {
+
+    private static final LocalTimeType singleton = new LocalTimeType();
+    public static LocalTimeType getSingleton() {
+        try {
+            Class.forName("java.time.LocalTime", false, null);
+        } catch (ClassNotFoundException e) {
+            return null; // No java.time on classpath;
+        }
+        return singleton; }
+    private LocalTimeType() { super(SqlType.LOCAL_TIME, new Class<?>[] { LocalTime.class }); }
+    protected LocalTimeType(SqlType sqlType, Class<?>[] classes) { super(sqlType, classes); }
+
+    @Override
+    public Object parseDefaultString(FieldType fieldType, String defaultStr) throws SQLException {
+        try {
+            return LocalTime.parse(defaultStr, DateTimeFormatter.ofPattern("HH:mm:ss"));
+        } catch (NumberFormatException e) {
+            throw SqlExceptionUtil.create("Problems with field " + fieldType +
+                    " parsing default LocalDateTime value: " + defaultStr, e);
+        }
+    }
+
+    @Override
+    public Object resultToSqlArg(FieldType fieldType, DatabaseResults results, int columnPos) throws SQLException {
+        return results.getLocalTime(columnPos);
+    }
+
+    @Override
+    public boolean isValidForVersion() {
+        return true;
+    }
+
+    @Override
+    public Object moveToNextValue(Object currentValue) {
+        LocalTime time = (LocalTime) currentValue;
+        return time.plusNanos(1);
+    }
+
+    @Override
+    public boolean isValidForField(Field field) {
+        return (field.getType() == LocalTime.class);
+    }
+
+    @Override
+    public boolean isArgumentHolderRequired() {
+        return true;
+    }
 }

--- a/src/main/java/com/j256/ormlite/field/types/LocalTimeType.java
+++ b/src/main/java/com/j256/ormlite/field/types/LocalTimeType.java
@@ -31,7 +31,7 @@ public class LocalTimeType extends BaseDataType {
     @Override
     public Object parseDefaultString(FieldType fieldType, String defaultStr) throws SQLException {
         try {
-            return LocalTime.parse(defaultStr, DateTimeFormatter.ofPattern("HH:mm:ss"));
+            return LocalTime.parse(defaultStr, DateTimeFormatter.ofPattern("HH:mm:ss[.SSSSSS]"));
         } catch (NumberFormatException e) {
             throw SqlExceptionUtil.create("Problems with field " + fieldType +
                     " parsing default LocalDateTime value: " + defaultStr, e);

--- a/src/main/java/com/j256/ormlite/field/types/LocalTimeType.java
+++ b/src/main/java/com/j256/ormlite/field/types/LocalTimeType.java
@@ -1,0 +1,4 @@
+package com.j256.ormlite.field.types;
+
+public class LocalTimeType {
+}

--- a/src/main/java/com/j256/ormlite/field/types/OffsetDateTimeType.java
+++ b/src/main/java/com/j256/ormlite/field/types/OffsetDateTimeType.java
@@ -1,0 +1,4 @@
+package com.j256.ormlite.field.types;
+
+public class OffsetDateTimeType {
+}

--- a/src/main/java/com/j256/ormlite/field/types/OffsetDateTimeType.java
+++ b/src/main/java/com/j256/ormlite/field/types/OffsetDateTimeType.java
@@ -31,7 +31,7 @@ public class OffsetDateTimeType extends BaseDataType {
     @Override
     public Object parseDefaultString(FieldType fieldType, String defaultStr) throws SQLException {
         try {
-            return OffsetDateTime.parse(defaultStr, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSSx"));
+            return OffsetDateTime.parse(defaultStr, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss[.SSS]x"));
         } catch (NumberFormatException e) {
             throw SqlExceptionUtil.create("Problems with field " + fieldType +
                     " parsing default LocalDateTime value: " + defaultStr, e);

--- a/src/main/java/com/j256/ormlite/field/types/OffsetDateTimeType.java
+++ b/src/main/java/com/j256/ormlite/field/types/OffsetDateTimeType.java
@@ -1,4 +1,66 @@
 package com.j256.ormlite.field.types;
 
-public class OffsetDateTimeType {
+import java.lang.reflect.Field;
+import java.sql.SQLException;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+
+import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.field.SqlType;
+import com.j256.ormlite.misc.SqlExceptionUtil;
+import com.j256.ormlite.support.DatabaseResults;
+
+/**
+ * A custom persister that is able to store the java.time.LocalDate class in the database as Date object.
+ *
+ * @author graynk
+ */
+public class OffsetDateTimeType extends BaseDataType {
+
+    private static final OffsetDateTimeType singleton = new OffsetDateTimeType();
+    public static OffsetDateTimeType getSingleton() {
+        try {
+            Class.forName("java.time.OffsetDateTime", false, null);
+        } catch (ClassNotFoundException e) {
+            return null; // No java.time on classpath;
+        }
+        return singleton; }
+    private OffsetDateTimeType() { super(SqlType.OFFSET_DATE_TIME, new Class<?>[] { OffsetDateTime.class }); }
+    protected OffsetDateTimeType(SqlType sqlType, Class<?>[] classes) { super(sqlType, classes); }
+
+    @Override
+    public Object parseDefaultString(FieldType fieldType, String defaultStr) throws SQLException {
+        try {
+            return OffsetDateTime.parse(defaultStr, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSSx"));
+        } catch (NumberFormatException e) {
+            throw SqlExceptionUtil.create("Problems with field " + fieldType +
+                    " parsing default LocalDateTime value: " + defaultStr, e);
+        }
+    }
+
+    @Override
+    public Object resultToSqlArg(FieldType fieldType, DatabaseResults results, int columnPos) throws SQLException {
+        return results.getOffsetDateTime(columnPos);
+    }
+
+    @Override
+    public boolean isValidForVersion() {
+        return true;
+    }
+
+    @Override
+    public Object moveToNextValue(Object currentValue) {
+        OffsetDateTime datetime = (OffsetDateTime) currentValue;
+        return datetime.plusNanos(1);
+    }
+
+    @Override
+    public boolean isValidForField(Field field) {
+        return (field.getType() == OffsetDateTime.class);
+    }
+
+    @Override
+    public boolean isArgumentHolderRequired() {
+        return true;
+    }
 }

--- a/src/main/java/com/j256/ormlite/field/types/OffsetTimeSqlType.java
+++ b/src/main/java/com/j256/ormlite/field/types/OffsetTimeSqlType.java
@@ -2,9 +2,9 @@ package com.j256.ormlite.field.types;
 
 import java.lang.reflect.Field;
 import java.sql.SQLException;
-import java.time.Instant;
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
+import java.time.OffsetTime;
 import java.time.format.DateTimeFormatter;
 
 import com.j256.ormlite.field.FieldType;
@@ -17,18 +17,18 @@ import com.j256.ormlite.support.DatabaseResults;
  *
  * @author graynk
  */
-public class InstantType extends BaseDataType {
+public class OffsetTimeSqlType extends BaseDataType {
 
-    private static final InstantType singleton = new InstantType();
-    public static InstantType getSingleton() {
+    private static final OffsetTimeSqlType singleton = new OffsetTimeSqlType();
+    public static OffsetTimeSqlType getSingleton() {
         try {
-            Class.forName("java.time.Instant", false, null);
+            Class.forName("java.time.OffsetTime", false, null);
         } catch (ClassNotFoundException e) {
             return null; // No java.time on classpath;
         }
         return singleton; }
-    private InstantType() { super(SqlType.OFFSET_DATE_TIME, new Class<?>[] { Instant.class }); }
-    protected InstantType(SqlType sqlType, Class<?>[] classes) { super(sqlType, classes); }
+    private OffsetTimeSqlType() { super(SqlType.OFFSET_DATE_TIME, new Class<?>[] { OffsetTime.class }); }
+    protected OffsetTimeSqlType(SqlType sqlType, Class<?>[] classes) { super(sqlType, classes); }
 
     @Override
     public Object parseDefaultString(FieldType fieldType, String defaultStr) throws SQLException {
@@ -48,13 +48,13 @@ public class InstantType extends BaseDataType {
     @Override
     public Object sqlArgToJava(FieldType fieldType, Object sqlArg, int columnPos) {
         OffsetDateTime value = (OffsetDateTime) sqlArg;
-        return value.toInstant();
+        return value.toOffsetTime();
     }
 
     @Override
     public Object javaToSqlArg(FieldType fieldType, Object javaObject) {
-        Instant instant = (Instant) javaObject;
-        return OffsetDateTime.ofInstant(instant, ZoneOffset.UTC);
+        OffsetTime time = (OffsetTime) javaObject;
+        return time.atDate(LocalDate.ofEpochDay(0));
     }
 
     @Override
@@ -64,13 +64,13 @@ public class InstantType extends BaseDataType {
 
     @Override
     public Object moveToNextValue(Object currentValue) {
-        Instant datetime = (Instant) currentValue;
-        return datetime.plusNanos(1);
+        OffsetTime time = (OffsetTime) currentValue;
+        return time.plusNanos(1);
     }
 
     @Override
     public boolean isValidForField(Field field) {
-        return (field.getType() == Instant.class);
+        return (field.getType() == OffsetTime.class);
     }
 
     @Override

--- a/src/main/java/com/j256/ormlite/field/types/OffsetTimeType.java
+++ b/src/main/java/com/j256/ormlite/field/types/OffsetTimeType.java
@@ -31,7 +31,7 @@ public class OffsetTimeType extends BaseDataType {
     @Override
     public Object parseDefaultString(FieldType fieldType, String defaultStr) throws SQLException {
         try {
-            return OffsetTime.parse(defaultStr, DateTimeFormatter.ofPattern("HH:mm:ssx"));
+            return OffsetTime.parse(defaultStr, DateTimeFormatter.ofPattern("HH:mm:ss[.SSS]x"));
         } catch (NumberFormatException e) {
             throw SqlExceptionUtil.create("Problems with field " + fieldType +
                     " parsing default LocalDateTime value: " + defaultStr, e);

--- a/src/main/java/com/j256/ormlite/field/types/OffsetTimeType.java
+++ b/src/main/java/com/j256/ormlite/field/types/OffsetTimeType.java
@@ -1,4 +1,66 @@
 package com.j256.ormlite.field.types;
 
-public class OffsetTimeType {
+import java.lang.reflect.Field;
+import java.sql.SQLException;
+import java.time.OffsetTime;
+import java.time.format.DateTimeFormatter;
+
+import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.field.SqlType;
+import com.j256.ormlite.misc.SqlExceptionUtil;
+import com.j256.ormlite.support.DatabaseResults;
+
+/**
+ * A custom persister that is able to store the java.time.LocalDate class in the database as Date object.
+ *
+ * @author graynk
+ */
+public class OffsetTimeType extends BaseDataType {
+
+    private static final OffsetTimeType singleton = new OffsetTimeType();
+    public static OffsetTimeType getSingleton() {
+        try {
+            Class.forName("java.time.OffsetTime", false, null);
+        } catch (ClassNotFoundException e) {
+            return null; // No java.time on classpath;
+        }
+        return singleton; }
+    private OffsetTimeType() { super(SqlType.OFFSET_TIME, new Class<?>[] { OffsetTime.class }); }
+    protected OffsetTimeType(SqlType sqlType, Class<?>[] classes) { super(sqlType, classes); }
+
+    @Override
+    public Object parseDefaultString(FieldType fieldType, String defaultStr) throws SQLException {
+        try {
+            return OffsetTime.parse(defaultStr, DateTimeFormatter.ofPattern("HH:mm:ssx"));
+        } catch (NumberFormatException e) {
+            throw SqlExceptionUtil.create("Problems with field " + fieldType +
+                    " parsing default LocalDateTime value: " + defaultStr, e);
+        }
+    }
+
+    @Override
+    public Object resultToSqlArg(FieldType fieldType, DatabaseResults results, int columnPos) throws SQLException {
+        return results.getOffsetTime(columnPos);
+    }
+
+    @Override
+    public boolean isValidForVersion() {
+        return true;
+    }
+
+    @Override
+    public Object moveToNextValue(Object currentValue) {
+        OffsetTime time = (OffsetTime) currentValue;
+        return time.plusNanos(1);
+    }
+
+    @Override
+    public boolean isValidForField(Field field) {
+        return (field.getType() == OffsetTime.class);
+    }
+
+    @Override
+    public boolean isArgumentHolderRequired() {
+        return true;
+    }
 }

--- a/src/main/java/com/j256/ormlite/field/types/OffsetTimeType.java
+++ b/src/main/java/com/j256/ormlite/field/types/OffsetTimeType.java
@@ -1,0 +1,4 @@
+package com.j256.ormlite.field.types;
+
+public class OffsetTimeType {
+}

--- a/src/main/java/com/j256/ormlite/support/DatabaseResults.java
+++ b/src/main/java/com/j256/ormlite/support/DatabaseResults.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.math.BigDecimal;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.time.*;
 
 import com.j256.ormlite.dao.ObjectCache;
 
@@ -140,6 +141,31 @@ public interface DatabaseResults extends Closeable {
 	 * Returns the SQL timestamp value from the results at the column index.
 	 */
 	public Timestamp getTimestamp(int columnIndex) throws SQLException;
+
+	/**
+	 * Returns the LocalDate value from the results at the column index
+	 */
+	public LocalDate getLocalDate(int columnIndex) throws SQLException;
+
+	/**
+	 * Returns the LocalTime value from the results at the column index.
+	 */
+	public LocalTime getLocalTime(int columnIndex) throws SQLException;
+
+	/**
+	 * Returns the LocalDateTime value from the results at the column index.
+	 */
+	public LocalDateTime getLocalDateTime(int columnIndex) throws SQLException;
+
+	/**
+	 * Returns the OffsetTime value from the results at the column index.
+	 */
+	public OffsetTime getOffsetTime(int columnIndex) throws SQLException;
+
+	/**
+	 * Returns the OffsetDateTime value from the results at the column index.
+	 */
+	public OffsetDateTime getOffsetDateTime(int columnIndex) throws SQLException;
 
 	/**
 	 * Returns an input stream for a blob value from the results at the column index.

--- a/src/main/java/com/j256/ormlite/support/DatabaseResults.java
+++ b/src/main/java/com/j256/ormlite/support/DatabaseResults.java
@@ -3,7 +3,9 @@ package com.j256.ormlite.support;
 import java.io.Closeable;
 import java.io.InputStream;
 import java.math.BigDecimal;
+import java.sql.Date;
 import java.sql.SQLException;
+import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.*;
 
@@ -141,6 +143,16 @@ public interface DatabaseResults extends Closeable {
 	 * Returns the SQL timestamp value from the results at the column index.
 	 */
 	public Timestamp getTimestamp(int columnIndex) throws SQLException;
+
+	/**
+	 * Returns the SQL date value from the results at the column index.
+	 */
+	public Date getDate(int columnIndex) throws SQLException;
+
+	/**
+	 * Returns the SQL time value from the results at the column index.
+	 */
+	public Time getTime(int columnIndex) throws SQLException;
 
 	/**
 	 * Returns the LocalDate value from the results at the column index

--- a/src/test/java/com/j256/ormlite/dao/BaseDaoImplTest.java
+++ b/src/test/java/com/j256/ormlite/dao/BaseDaoImplTest.java
@@ -1642,12 +1642,10 @@ public class BaseDaoImplTest extends BaseCoreTest {
 			callC++;
 		}
 
-		@Override
 		public void close() {
 
 		}
 
-		@Override
 		public void remove() {
 
 		}

--- a/src/test/java/com/j256/ormlite/dao/BaseDaoImplTest.java
+++ b/src/test/java/com/j256/ormlite/dao/BaseDaoImplTest.java
@@ -1641,6 +1641,16 @@ public class BaseDaoImplTest extends BaseCoreTest {
 		public void fire(Connection conn, Object[] oldRow, Object[] newRow) {
 			callC++;
 		}
+
+		@Override
+		public void close() {
+
+		}
+
+		@Override
+		public void remove() {
+
+		}
 	}
 
 	@Test

--- a/src/test/java/com/j256/ormlite/field/types/InstantTypeTest.java
+++ b/src/test/java/com/j256/ormlite/field/types/InstantTypeTest.java
@@ -1,7 +1,77 @@
 package com.j256.ormlite.field.types;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
-public class InstantTypeTest {
+import java.sql.SQLException;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
 
+import org.junit.Test;
+
+import com.j256.ormlite.dao.Dao;
+import com.j256.ormlite.field.DataType;
+import com.j256.ormlite.field.DatabaseField;
+import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.table.DatabaseTable;
+
+public class InstantTypeTest extends BaseTypeTest {
+
+    private static final String INSTANT_COLUMN = "instant";
+
+    @Test
+    public void testInstant() throws Exception {
+        Class<InstantTable> clazz = InstantTable.class;
+        Dao<InstantTable, Object> dao = createDao(clazz, true);
+        Instant val = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS");
+        String valStr = val.toString();
+        InstantTable foo = new InstantTable();
+        foo.instant = val;
+        assertEquals(1, dao.create(foo));
+
+        testType(dao, foo, clazz, val, val, val, valStr, DataType.INSTANT, INSTANT_COLUMN, false,
+                true, true, false, true, false,
+                true, false);
+    }
+
+    @Test
+    public void testDateNull() throws Exception {
+        Class<InstantTable> clazz = InstantTable.class;
+        Dao<InstantTable, Object> dao = createDao(clazz, true);
+        InstantTable foo = new InstantTable();
+        assertEquals(1, dao.create(foo));
+        testType(dao, foo, clazz, null, null, null, null, DataType.INSTANT,
+                INSTANT_COLUMN,
+                false, true, true, false, true,
+                false, true, false);
+    }
+
+    @Test(expected = DateTimeParseException.class)
+    public void testDateParseInvalid() throws Exception {
+        FieldType fieldType = FieldType.createFieldType(connectionSource, TABLE_NAME,
+                InstantTable.class.getDeclaredField(INSTANT_COLUMN), InstantTable.class);
+        DataType.INSTANT.getDataPersister().parseDefaultString(fieldType, "not valid instant string");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidDateField() throws Exception {
+        FieldType.createFieldType(connectionSource, TABLE_NAME, InvalidDate.class.getDeclaredField("notInstant"),
+                InstantTable.class);
+    }
+
+    /* ============================================================================================ */
+
+    @DatabaseTable
+    protected static class InvalidDate {
+        @DatabaseField(dataType = DataType.INSTANT)
+        String notInstant;
+    }
+
+    @DatabaseTable(tableName = TABLE_NAME)
+    protected static class InstantTable {
+        @DatabaseField(columnName = INSTANT_COLUMN)
+        Instant instant;
+    }
 }

--- a/src/test/java/com/j256/ormlite/field/types/InstantTypeTest.java
+++ b/src/test/java/com/j256/ormlite/field/types/InstantTypeTest.java
@@ -1,0 +1,7 @@
+package com.j256.ormlite.field.types;
+
+import static org.junit.Assert.*;
+
+public class InstantTypeTest {
+
+}

--- a/src/test/java/com/j256/ormlite/field/types/InstantTypeTest.java
+++ b/src/test/java/com/j256/ormlite/field/types/InstantTypeTest.java
@@ -2,11 +2,11 @@ package com.j256.ormlite.field.types;
 
 import static org.junit.Assert.assertEquals;
 
-import java.sql.SQLException;
 import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.time.temporal.ChronoUnit;
 
 import org.junit.Test;
 
@@ -24,14 +24,15 @@ public class InstantTypeTest extends BaseTypeTest {
     public void testInstant() throws Exception {
         Class<InstantTable> clazz = InstantTable.class;
         Dao<InstantTable, Object> dao = createDao(clazz, true);
-        Instant val = Instant.now().truncatedTo(ChronoUnit.MILLIS);
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS");
-        String valStr = val.toString();
+        Instant val = Instant.now();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss[.SSS]x");
+        OffsetDateTime val2 = OffsetDateTime.ofInstant(val, ZoneOffset.UTC);
+        String valStr = formatter.format(val2);
         InstantTable foo = new InstantTable();
         foo.instant = val;
         assertEquals(1, dao.create(foo));
 
-        testType(dao, foo, clazz, val, val, val, valStr, DataType.INSTANT, INSTANT_COLUMN, false,
+        testType(dao, foo, clazz, val, val2, val2, valStr, DataType.INSTANT, INSTANT_COLUMN, false,
                 true, true, false, true, false,
                 true, false);
     }

--- a/src/test/java/com/j256/ormlite/field/types/LocalDateSqlTypeTest.java
+++ b/src/test/java/com/j256/ormlite/field/types/LocalDateSqlTypeTest.java
@@ -2,6 +2,7 @@ package com.j256.ormlite.field.types;
 
 import static org.junit.Assert.assertEquals;
 
+import java.sql.Date;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -14,7 +15,7 @@ import com.j256.ormlite.field.DatabaseField;
 import com.j256.ormlite.field.FieldType;
 import com.j256.ormlite.table.DatabaseTable;
 
-public class LocalDateTypeTest extends BaseTypeTest {
+public class LocalDateSqlTypeTest extends BaseTypeTest {
 
     private static final String DATE_COLUMN = "date";
 
@@ -23,14 +24,14 @@ public class LocalDateTypeTest extends BaseTypeTest {
         Class<DateTable> clazz = DateTable.class;
         Dao<DateTable, Object> dao = createDao(clazz, true);
         LocalDate val = LocalDate.now();
-        LocalDate val2 = LocalDate.now();
+        Date val2 = Date.valueOf(val);
         DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE;
         String valStr = formatter.format(val);
         DateTable foo = new DateTable();
         foo.date = val;
         assertEquals(1, dao.create(foo));
 
-        testType(dao, foo, clazz, val, val2, val2, valStr, DataType.LOCAL_DATE, DATE_COLUMN, false,
+        testType(dao, foo, clazz, val, val2, val2, valStr, DataType.LOCAL_DATE_SQL, DATE_COLUMN, false,
                 true, true, false, true, false,
                 true, false);
     }
@@ -41,7 +42,7 @@ public class LocalDateTypeTest extends BaseTypeTest {
         Dao<DateTable, Object> dao = createDao(clazz, true);
         DateTable foo = new DateTable();
         assertEquals(1, dao.create(foo));
-        testType(dao, foo, clazz, null, null, null, null, DataType.LOCAL_DATE, DATE_COLUMN,
+        testType(dao, foo, clazz, null, null, null, null, DataType.LOCAL_DATE_SQL, DATE_COLUMN,
                 false, true, true, false, true,
                 false, true, false);
     }
@@ -63,13 +64,13 @@ public class LocalDateTypeTest extends BaseTypeTest {
 
     @DatabaseTable
     protected static class InvalidDate {
-        @DatabaseField(dataType = DataType.LOCAL_DATE)
+        @DatabaseField(dataType = DataType.LOCAL_DATE_SQL)
         String notDate;
     }
 
     @DatabaseTable(tableName = TABLE_NAME)
     protected static class DateTable {
-        @DatabaseField(columnName = DATE_COLUMN)
+        @DatabaseField(columnName = DATE_COLUMN, dataType = DataType.LOCAL_DATE_SQL)
         LocalDate date;
     }
 }

--- a/src/test/java/com/j256/ormlite/field/types/LocalDateTimeSqlTypeTest.java
+++ b/src/test/java/com/j256/ormlite/field/types/LocalDateTimeSqlTypeTest.java
@@ -2,11 +2,10 @@ package com.j256.ormlite.field.types;
 
 import static org.junit.Assert.assertEquals;
 
-import java.sql.SQLException;
-import java.time.OffsetDateTime;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.time.temporal.ChronoUnit;
 
 import org.junit.Test;
 
@@ -16,7 +15,7 @@ import com.j256.ormlite.field.DatabaseField;
 import com.j256.ormlite.field.FieldType;
 import com.j256.ormlite.table.DatabaseTable;
 
-public class OffsetDateTimeTypeTest extends BaseTypeTest {
+public class LocalDateTimeSqlTypeTest extends BaseTypeTest {
 
     private static final String DATE_TIME_COLUMN = "dateTime";
 
@@ -24,16 +23,15 @@ public class OffsetDateTimeTypeTest extends BaseTypeTest {
     public void testDateTime() throws Exception {
         Class<DateTimeTable> clazz = DateTimeTable.class;
         Dao<DateTimeTable, Object> dao = createDao(clazz, true);
-        OffsetDateTime val = OffsetDateTime.now().truncatedTo(ChronoUnit.MILLIS);
-
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss[.SSS]x");
+        LocalDateTime val = LocalDateTime.now();
+        Timestamp val2 = Timestamp.valueOf(val);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
         String valStr = formatter.format(val);
-
         DateTimeTable foo = new DateTimeTable();
         foo.dateTime = val;
         assertEquals(1, dao.create(foo));
 
-        testType(dao, foo, clazz, val, val, val, valStr, DataType.OFFSET_DATE_TIME, DATE_TIME_COLUMN, false,
+        testType(dao, foo, clazz, val, val2, val2, valStr, DataType.LOCAL_DATE_TIME_SQL, DATE_TIME_COLUMN, false,
                 true, true, false, true, false,
                 true, false);
     }
@@ -44,7 +42,7 @@ public class OffsetDateTimeTypeTest extends BaseTypeTest {
         Dao<DateTimeTable, Object> dao = createDao(clazz, true);
         DateTimeTable foo = new DateTimeTable();
         assertEquals(1, dao.create(foo));
-        testType(dao, foo, clazz, null, null, null, null, DataType.OFFSET_DATE_TIME,
+        testType(dao, foo, clazz, null, null, null, null, DataType.LOCAL_DATE_TIME_SQL,
                 DATE_TIME_COLUMN,
                 false, true, true, false, true,
                 false, true, false);
@@ -54,7 +52,7 @@ public class OffsetDateTimeTypeTest extends BaseTypeTest {
     public void testDateParseInvalid() throws Exception {
         FieldType fieldType = FieldType.createFieldType(connectionSource, TABLE_NAME,
                 DateTimeTable.class.getDeclaredField(DATE_TIME_COLUMN), DateTimeTable.class);
-        DataType.OFFSET_DATE_TIME.getDataPersister().parseDefaultString(fieldType, "not valid datetime string");
+        DataType.LOCAL_DATE_TIME.getDataPersister().parseDefaultString(fieldType, "not valid datetime string");
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -67,13 +65,13 @@ public class OffsetDateTimeTypeTest extends BaseTypeTest {
 
     @DatabaseTable
     protected static class InvalidDate {
-        @DatabaseField(dataType = DataType.OFFSET_DATE_TIME)
+        @DatabaseField(dataType = DataType.LOCAL_DATE_TIME_SQL)
         String notDateTime;
     }
 
     @DatabaseTable(tableName = TABLE_NAME)
     protected static class DateTimeTable {
-        @DatabaseField(columnName = DATE_TIME_COLUMN)
-        OffsetDateTime dateTime;
+        @DatabaseField(columnName = DATE_TIME_COLUMN, dataType = DataType.LOCAL_DATE_TIME_SQL)
+        LocalDateTime dateTime;
     }
 }

--- a/src/test/java/com/j256/ormlite/field/types/LocalDateTimeTypeTest.java
+++ b/src/test/java/com/j256/ormlite/field/types/LocalDateTimeTypeTest.java
@@ -1,7 +1,77 @@
 package com.j256.ormlite.field.types;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
-public class LocalDateTimeTypeTest {
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
 
+import org.junit.Test;
+
+import com.j256.ormlite.dao.Dao;
+import com.j256.ormlite.field.DataType;
+import com.j256.ormlite.field.DatabaseField;
+import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.table.DatabaseTable;
+
+public class LocalDateTimeTypeTest extends BaseTypeTest {
+
+    private static final String DATE_TIME_COLUMN = "dateTime";
+
+    @Test
+    public void testDateTime() throws Exception {
+        Class<DateTimeTable> clazz = DateTimeTable.class;
+        Dao<DateTimeTable, Object> dao = createDao(clazz, true);
+        LocalDateTime val = LocalDateTime.now();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS");
+        String valStr = formatter.format(val);
+        DateTimeTable foo = new DateTimeTable();
+        foo.dateTime = val;
+        assertEquals(1, dao.create(foo));
+
+        testType(dao, foo, clazz, val, val, val, valStr, DataType.LOCAL_DATE_TIME, DATE_TIME_COLUMN, false,
+                true, true, false, true, false,
+                true, false);
+    }
+
+    @Test
+    public void testDateNull() throws Exception {
+        Class<DateTimeTable> clazz = DateTimeTable.class;
+        Dao<DateTimeTable, Object> dao = createDao(clazz, true);
+        DateTimeTable foo = new DateTimeTable();
+        assertEquals(1, dao.create(foo));
+        testType(dao, foo, clazz, null, null, null, null, DataType.LOCAL_DATE_TIME, 
+                DATE_TIME_COLUMN,
+                false, true, true, false, true,
+                false, true, false);
+    }
+
+    @Test(expected = DateTimeParseException.class)
+    public void testDateParseInvalid() throws Exception {
+        FieldType fieldType = FieldType.createFieldType(connectionSource, TABLE_NAME,
+                DateTimeTable.class.getDeclaredField(DATE_TIME_COLUMN), DateTimeTable.class);
+        DataType.LOCAL_DATE_TIME.getDataPersister().parseDefaultString(fieldType, "not valid datetime string");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidDateField() throws Exception {
+        FieldType.createFieldType(connectionSource, TABLE_NAME, InvalidDate.class.getDeclaredField("notDateTime"),
+                DateTimeTable.class);
+    }
+
+    /* ============================================================================================ */
+
+    @DatabaseTable
+    protected static class InvalidDate {
+        @DatabaseField(dataType = DataType.LOCAL_DATE_TIME)
+        String notDateTime;
+    }
+
+    @DatabaseTable(tableName = TABLE_NAME)
+    protected static class DateTimeTable {
+        @DatabaseField(columnName = DATE_TIME_COLUMN)
+        LocalDateTime dateTime;
+    }
 }

--- a/src/test/java/com/j256/ormlite/field/types/LocalDateTimeTypeTest.java
+++ b/src/test/java/com/j256/ormlite/field/types/LocalDateTimeTypeTest.java
@@ -2,11 +2,9 @@ package com.j256.ormlite.field.types;
 
 import static org.junit.Assert.assertEquals;
 
-import java.sql.SQLException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.time.temporal.ChronoUnit;
 
 import org.junit.Test;
 
@@ -25,7 +23,7 @@ public class LocalDateTimeTypeTest extends BaseTypeTest {
         Class<DateTimeTable> clazz = DateTimeTable.class;
         Dao<DateTimeTable, Object> dao = createDao(clazz, true);
         LocalDateTime val = LocalDateTime.now();
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
         String valStr = formatter.format(val);
         DateTimeTable foo = new DateTimeTable();
         foo.dateTime = val;

--- a/src/test/java/com/j256/ormlite/field/types/LocalDateTimeTypeTest.java
+++ b/src/test/java/com/j256/ormlite/field/types/LocalDateTimeTypeTest.java
@@ -1,0 +1,7 @@
+package com.j256.ormlite.field.types;
+
+import static org.junit.Assert.*;
+
+public class LocalDateTimeTypeTest {
+
+}

--- a/src/test/java/com/j256/ormlite/field/types/LocalDateTypeTest.java
+++ b/src/test/java/com/j256/ormlite/field/types/LocalDateTypeTest.java
@@ -1,0 +1,7 @@
+package com.j256.ormlite.field.types;
+
+import static org.junit.Assert.*;
+
+public class LocalDateTypeTest {
+
+}

--- a/src/test/java/com/j256/ormlite/field/types/LocalDateTypeTest.java
+++ b/src/test/java/com/j256/ormlite/field/types/LocalDateTypeTest.java
@@ -1,7 +1,76 @@
 package com.j256.ormlite.field.types;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
-public class LocalDateTypeTest {
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
+import org.junit.Test;
+
+import com.j256.ormlite.dao.Dao;
+import com.j256.ormlite.field.DataType;
+import com.j256.ormlite.field.DatabaseField;
+import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.table.DatabaseTable;
+
+public class LocalDateTypeTest extends BaseTypeTest {
+
+    private static final String DATE_COLUMN = "date";
+
+    @Test
+    public void testDate() throws Exception {
+        Class<DateTable> clazz = DateTable.class;
+        Dao<DateTable, Object> dao = createDao(clazz, true);
+        LocalDate val = LocalDate.now();
+        LocalDate val2 = LocalDate.now();
+        DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE;
+        String valStr = formatter.format(val);
+        DateTable foo = new DateTable();
+        foo.date = val;
+        assertEquals(1, dao.create(foo));
+
+        testType(dao, foo, clazz, val, val2, val2, valStr, DataType.LOCAL_DATE, DATE_COLUMN, false,
+                true, true, false, true, false,
+                true, false);
+    }
+
+    @Test
+    public void testDateNull() throws Exception {
+        Class<DateTable> clazz = DateTable.class;
+        Dao<DateTable, Object> dao = createDao(clazz, true);
+        DateTable foo = new DateTable();
+        assertEquals(1, dao.create(foo));
+        testType(dao, foo, clazz, null, null, null, null, DataType.LOCAL_DATE, DATE_COLUMN,
+                false, true, true, false, true,
+                false, true, false);
+    }
+
+    @Test(expected = DateTimeParseException.class)
+    public void testDateParseInvalid() throws Exception {
+        FieldType fieldType = FieldType.createFieldType(connectionSource, TABLE_NAME,
+                DateTable.class.getDeclaredField(DATE_COLUMN), DateTable.class);
+        DataType.LOCAL_DATE.getDataPersister().parseDefaultString(fieldType, "not valid date string");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidDateField() throws Exception {
+        FieldType.createFieldType(connectionSource, TABLE_NAME, InvalidDate.class.getDeclaredField("notDate"),
+                DateTable.class);
+    }
+
+    /* ============================================================================================ */
+
+    @DatabaseTable
+    protected static class InvalidDate {
+        @DatabaseField(dataType = DataType.LOCAL_DATE)
+        String notDate;
+    }
+
+    @DatabaseTable(tableName = TABLE_NAME)
+    protected static class DateTable {
+        @DatabaseField(columnName = DATE_COLUMN)
+        LocalDate date;
+    }
 }

--- a/src/test/java/com/j256/ormlite/field/types/LocalTimeSqlTypeTest.java
+++ b/src/test/java/com/j256/ormlite/field/types/LocalTimeSqlTypeTest.java
@@ -2,7 +2,8 @@ package com.j256.ormlite.field.types;
 
 import static org.junit.Assert.assertEquals;
 
-import java.time.OffsetTime;
+import java.sql.Time;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
@@ -15,7 +16,7 @@ import com.j256.ormlite.field.DatabaseField;
 import com.j256.ormlite.field.FieldType;
 import com.j256.ormlite.table.DatabaseTable;
 
-public class OffsetTimeTypeTest extends BaseTypeTest {
+public class LocalTimeSqlTypeTest extends BaseTypeTest {
 
     private static final String TIME_COLUMN = "time";
 
@@ -23,14 +24,15 @@ public class OffsetTimeTypeTest extends BaseTypeTest {
     public void testTime() throws Exception {
         Class<TimeTable> clazz = TimeTable.class;
         Dao<TimeTable, Object> dao = createDao(clazz, true);
-        OffsetTime val = OffsetTime.now();
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss[.SSS]x");
+        LocalTime val = LocalTime.now().truncatedTo(ChronoUnit.SECONDS);
+        Time val2 = Time.valueOf(val);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss");
         String valStr = formatter.format(val);
         TimeTable foo = new TimeTable();
         foo.time = val;
         assertEquals(1, dao.create(foo));
 
-        testType(dao, foo, clazz, val, val, val, valStr, DataType.OFFSET_TIME, TIME_COLUMN, false,
+        testType(dao, foo, clazz, val, val2, val2, valStr, DataType.LOCAL_TIME_SQL, TIME_COLUMN, false,
                 true, true, false, true, false,
                 true, false);
     }
@@ -41,7 +43,7 @@ public class OffsetTimeTypeTest extends BaseTypeTest {
         Dao<TimeTable, Object> dao = createDao(clazz, true);
         TimeTable foo = new TimeTable();
         assertEquals(1, dao.create(foo));
-        testType(dao, foo, clazz, null, null, null, null, DataType.OFFSET_TIME, TIME_COLUMN,
+        testType(dao, foo, clazz, null, null, null, null, DataType.LOCAL_TIME_SQL, TIME_COLUMN,
                 false, true, true, false, true,
                 false, true, false);
     }
@@ -50,7 +52,7 @@ public class OffsetTimeTypeTest extends BaseTypeTest {
     public void testDateParseInvalid() throws Exception {
         FieldType fieldType = FieldType.createFieldType(connectionSource, TABLE_NAME,
                 TimeTable.class.getDeclaredField(TIME_COLUMN), TimeTable.class);
-        DataType.OFFSET_TIME.getDataPersister().parseDefaultString(fieldType, "not valid time string");
+        DataType.LOCAL_TIME_SQL.getDataPersister().parseDefaultString(fieldType, "not valid time string");
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -63,13 +65,13 @@ public class OffsetTimeTypeTest extends BaseTypeTest {
 
     @DatabaseTable
     protected static class InvalidDate {
-        @DatabaseField(dataType = DataType.OFFSET_TIME)
+        @DatabaseField(dataType = DataType.LOCAL_TIME_SQL)
         String notTime;
     }
 
     @DatabaseTable(tableName = TABLE_NAME)
     protected static class TimeTable {
-        @DatabaseField(columnName = TIME_COLUMN)
-        OffsetTime time;
+        @DatabaseField(columnName = TIME_COLUMN, dataType = DataType.LOCAL_TIME_SQL)
+        LocalTime time;
     }
 }

--- a/src/test/java/com/j256/ormlite/field/types/LocalTimeTypeTest.java
+++ b/src/test/java/com/j256/ormlite/field/types/LocalTimeTypeTest.java
@@ -1,0 +1,7 @@
+package com.j256.ormlite.field.types;
+
+import static org.junit.Assert.*;
+
+public class LocalTimeTypeTest {
+
+}

--- a/src/test/java/com/j256/ormlite/field/types/LocalTimeTypeTest.java
+++ b/src/test/java/com/j256/ormlite/field/types/LocalTimeTypeTest.java
@@ -2,7 +2,6 @@ package com.j256.ormlite.field.types;
 
 import static org.junit.Assert.assertEquals;
 
-import java.sql.SQLException;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;

--- a/src/test/java/com/j256/ormlite/field/types/LocalTimeTypeTest.java
+++ b/src/test/java/com/j256/ormlite/field/types/LocalTimeTypeTest.java
@@ -1,7 +1,76 @@
 package com.j256.ormlite.field.types;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
-public class LocalTimeTypeTest {
+import java.sql.SQLException;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
 
+import org.junit.Test;
+
+import com.j256.ormlite.dao.Dao;
+import com.j256.ormlite.field.DataType;
+import com.j256.ormlite.field.DatabaseField;
+import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.table.DatabaseTable;
+
+public class LocalTimeTypeTest extends BaseTypeTest {
+
+    private static final String TIME_COLUMN = "time";
+
+    @Test
+    public void testTime() throws Exception {
+        Class<TimeTable> clazz = TimeTable.class;
+        Dao<TimeTable, Object> dao = createDao(clazz, true);
+        LocalTime val = LocalTime.now().truncatedTo(ChronoUnit.SECONDS);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss");
+        String valStr = formatter.format(val);
+        TimeTable foo = new TimeTable();
+        foo.time = val;
+        assertEquals(1, dao.create(foo));
+
+        testType(dao, foo, clazz, val, val, val, valStr, DataType.LOCAL_TIME, TIME_COLUMN, false,
+                true, true, false, true, false,
+                true, false);
+    }
+
+    @Test
+    public void testDateNull() throws Exception {
+        Class<TimeTable> clazz = TimeTable.class;
+        Dao<TimeTable, Object> dao = createDao(clazz, true);
+        TimeTable foo = new TimeTable();
+        assertEquals(1, dao.create(foo));
+        testType(dao, foo, clazz, null, null, null, null, DataType.LOCAL_TIME, TIME_COLUMN,
+                false, true, true, false, true,
+                false, true, false);
+    }
+
+    @Test(expected = DateTimeParseException.class)
+    public void testDateParseInvalid() throws Exception {
+        FieldType fieldType = FieldType.createFieldType(connectionSource, TABLE_NAME,
+                TimeTable.class.getDeclaredField(TIME_COLUMN), TimeTable.class);
+        DataType.LOCAL_TIME.getDataPersister().parseDefaultString(fieldType, "not valid time string");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidDateField() throws Exception {
+        FieldType.createFieldType(connectionSource, TABLE_NAME, InvalidDate.class.getDeclaredField("notTime"),
+                TimeTable.class);
+    }
+
+    /* ============================================================================================ */
+
+    @DatabaseTable
+    protected static class InvalidDate {
+        @DatabaseField(dataType = DataType.LOCAL_TIME)
+        String notTime;
+    }
+
+    @DatabaseTable(tableName = TABLE_NAME)
+    protected static class TimeTable {
+        @DatabaseField(columnName = TIME_COLUMN)
+        LocalTime time;
+    }
 }

--- a/src/test/java/com/j256/ormlite/field/types/OffsetDateTimeTypeTest.java
+++ b/src/test/java/com/j256/ormlite/field/types/OffsetDateTimeTypeTest.java
@@ -1,0 +1,7 @@
+package com.j256.ormlite.field.types;
+
+import static org.junit.Assert.*;
+
+public class OffsetDateTimeTypeTest {
+
+}

--- a/src/test/java/com/j256/ormlite/field/types/OffsetDateTimeTypeTest.java
+++ b/src/test/java/com/j256/ormlite/field/types/OffsetDateTimeTypeTest.java
@@ -1,7 +1,79 @@
 package com.j256.ormlite.field.types;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
-public class OffsetDateTimeTypeTest {
+import java.sql.SQLException;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
 
+import org.junit.Test;
+
+import com.j256.ormlite.dao.Dao;
+import com.j256.ormlite.field.DataType;
+import com.j256.ormlite.field.DatabaseField;
+import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.table.DatabaseTable;
+
+public class OffsetDateTimeTypeTest extends BaseTypeTest {
+
+    private static final String DATE_TIME_COLUMN = "dateTime";
+
+    @Test
+    public void testDateTime() throws Exception {
+        Class<DateTimeTable> clazz = DateTimeTable.class;
+        Dao<DateTimeTable, Object> dao = createDao(clazz, true);
+        OffsetDateTime val = OffsetDateTime.now().truncatedTo(ChronoUnit.MILLIS);
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSSx");
+        String valStr = formatter.format(val);
+
+        DateTimeTable foo = new DateTimeTable();
+        foo.dateTime = val;
+        assertEquals(1, dao.create(foo));
+
+        testType(dao, foo, clazz, val, val, val, valStr, DataType.OFFSET_DATE_TIME, DATE_TIME_COLUMN, false,
+                true, true, false, true, false,
+                true, false);
+    }
+
+    @Test
+    public void testDateNull() throws Exception {
+        Class<DateTimeTable> clazz = DateTimeTable.class;
+        Dao<DateTimeTable, Object> dao = createDao(clazz, true);
+        DateTimeTable foo = new DateTimeTable();
+        assertEquals(1, dao.create(foo));
+        testType(dao, foo, clazz, null, null, null, null, DataType.OFFSET_DATE_TIME,
+                DATE_TIME_COLUMN,
+                false, true, true, false, true,
+                false, true, false);
+    }
+
+    @Test(expected = DateTimeParseException.class)
+    public void testDateParseInvalid() throws Exception {
+        FieldType fieldType = FieldType.createFieldType(connectionSource, TABLE_NAME,
+                DateTimeTable.class.getDeclaredField(DATE_TIME_COLUMN), DateTimeTable.class);
+        DataType.OFFSET_DATE_TIME.getDataPersister().parseDefaultString(fieldType, "not valid datetime string");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidDateField() throws Exception {
+        FieldType.createFieldType(connectionSource, TABLE_NAME, InvalidDate.class.getDeclaredField("notDateTime"),
+                DateTimeTable.class);
+    }
+
+    /* ============================================================================================ */
+
+    @DatabaseTable
+    protected static class InvalidDate {
+        @DatabaseField(dataType = DataType.OFFSET_DATE_TIME)
+        String notDateTime;
+    }
+
+    @DatabaseTable(tableName = TABLE_NAME)
+    protected static class DateTimeTable {
+        @DatabaseField(columnName = DATE_TIME_COLUMN)
+        OffsetDateTime dateTime;
+    }
 }

--- a/src/test/java/com/j256/ormlite/field/types/OffsetTimeSqlTypeTest.java
+++ b/src/test/java/com/j256/ormlite/field/types/OffsetTimeSqlTypeTest.java
@@ -2,10 +2,11 @@ package com.j256.ormlite.field.types;
 
 import static org.junit.Assert.assertEquals;
 
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.time.temporal.ChronoUnit;
 
 import org.junit.Test;
 
@@ -15,7 +16,7 @@ import com.j256.ormlite.field.DatabaseField;
 import com.j256.ormlite.field.FieldType;
 import com.j256.ormlite.table.DatabaseTable;
 
-public class OffsetTimeTypeTest extends BaseTypeTest {
+public class OffsetTimeSqlTypeTest extends BaseTypeTest {
 
     private static final String TIME_COLUMN = "time";
 
@@ -24,13 +25,14 @@ public class OffsetTimeTypeTest extends BaseTypeTest {
         Class<TimeTable> clazz = TimeTable.class;
         Dao<TimeTable, Object> dao = createDao(clazz, true);
         OffsetTime val = OffsetTime.now();
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss[.SSS]x");
-        String valStr = formatter.format(val);
+        OffsetDateTime val2 = val.atDate(LocalDate.ofEpochDay(0));
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss[.SSS]x");
+        String valStr = formatter.format(val2);
         TimeTable foo = new TimeTable();
         foo.time = val;
         assertEquals(1, dao.create(foo));
 
-        testType(dao, foo, clazz, val, val, val, valStr, DataType.OFFSET_TIME, TIME_COLUMN, false,
+        testType(dao, foo, clazz, val, val2, val2, valStr, DataType.OFFSET_TIME_SQL, TIME_COLUMN, false,
                 true, true, false, true, false,
                 true, false);
     }
@@ -41,7 +43,7 @@ public class OffsetTimeTypeTest extends BaseTypeTest {
         Dao<TimeTable, Object> dao = createDao(clazz, true);
         TimeTable foo = new TimeTable();
         assertEquals(1, dao.create(foo));
-        testType(dao, foo, clazz, null, null, null, null, DataType.OFFSET_TIME, TIME_COLUMN,
+        testType(dao, foo, clazz, null, null, null, null, DataType.OFFSET_TIME_SQL, TIME_COLUMN,
                 false, true, true, false, true,
                 false, true, false);
     }
@@ -50,7 +52,7 @@ public class OffsetTimeTypeTest extends BaseTypeTest {
     public void testDateParseInvalid() throws Exception {
         FieldType fieldType = FieldType.createFieldType(connectionSource, TABLE_NAME,
                 TimeTable.class.getDeclaredField(TIME_COLUMN), TimeTable.class);
-        DataType.OFFSET_TIME.getDataPersister().parseDefaultString(fieldType, "not valid time string");
+        DataType.OFFSET_TIME_SQL.getDataPersister().parseDefaultString(fieldType, "not valid time string");
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -63,13 +65,13 @@ public class OffsetTimeTypeTest extends BaseTypeTest {
 
     @DatabaseTable
     protected static class InvalidDate {
-        @DatabaseField(dataType = DataType.OFFSET_TIME)
+        @DatabaseField(dataType = DataType.OFFSET_TIME_SQL)
         String notTime;
     }
 
     @DatabaseTable(tableName = TABLE_NAME)
     protected static class TimeTable {
-        @DatabaseField(columnName = TIME_COLUMN)
+        @DatabaseField(columnName = TIME_COLUMN, dataType = DataType.OFFSET_TIME_SQL)
         OffsetTime time;
     }
 }

--- a/src/test/java/com/j256/ormlite/field/types/OffsetTimeTypeTest.java
+++ b/src/test/java/com/j256/ormlite/field/types/OffsetTimeTypeTest.java
@@ -1,7 +1,76 @@
 package com.j256.ormlite.field.types;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
-public class OffsetTimeTypeTest {
+import java.sql.SQLException;
+import java.time.OffsetTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
 
+import org.junit.Test;
+
+import com.j256.ormlite.dao.Dao;
+import com.j256.ormlite.field.DataType;
+import com.j256.ormlite.field.DatabaseField;
+import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.table.DatabaseTable;
+
+public class OffsetTimeTypeTest extends BaseTypeTest {
+
+    private static final String TIME_COLUMN = "time";
+
+    @Test
+    public void testTime() throws Exception {
+        Class<TimeTable> clazz = TimeTable.class;
+        Dao<TimeTable, Object> dao = createDao(clazz, true);
+        OffsetTime val = OffsetTime.now().truncatedTo(ChronoUnit.SECONDS);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ssx");
+        String valStr = formatter.format(val);
+        TimeTable foo = new TimeTable();
+        foo.time = val;
+        assertEquals(1, dao.create(foo));
+
+        testType(dao, foo, clazz, val, val, val, valStr, DataType.OFFSET_TIME, TIME_COLUMN, false,
+                true, true, false, true, false,
+                true, false);
+    }
+
+    @Test
+    public void testDateNull() throws Exception {
+        Class<TimeTable> clazz = TimeTable.class;
+        Dao<TimeTable, Object> dao = createDao(clazz, true);
+        TimeTable foo = new TimeTable();
+        assertEquals(1, dao.create(foo));
+        testType(dao, foo, clazz, null, null, null, null, DataType.OFFSET_TIME, TIME_COLUMN,
+                false, true, true, false, true,
+                false, true, false);
+    }
+
+    @Test(expected = DateTimeParseException.class)
+    public void testDateParseInvalid() throws Exception {
+        FieldType fieldType = FieldType.createFieldType(connectionSource, TABLE_NAME,
+                TimeTable.class.getDeclaredField(TIME_COLUMN), TimeTable.class);
+        DataType.OFFSET_TIME.getDataPersister().parseDefaultString(fieldType, "not valid time string");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidDateField() throws Exception {
+        FieldType.createFieldType(connectionSource, TABLE_NAME, InvalidDate.class.getDeclaredField("notTime"),
+                TimeTable.class);
+    }
+
+    /* ============================================================================================ */
+
+    @DatabaseTable
+    protected static class InvalidDate {
+        @DatabaseField(dataType = DataType.OFFSET_TIME)
+        String notTime;
+    }
+
+    @DatabaseTable(tableName = TABLE_NAME)
+    protected static class TimeTable {
+        @DatabaseField(columnName = TIME_COLUMN)
+        OffsetTime time;
+    }
 }

--- a/src/test/java/com/j256/ormlite/field/types/OffsetTimeTypeTest.java
+++ b/src/test/java/com/j256/ormlite/field/types/OffsetTimeTypeTest.java
@@ -1,0 +1,7 @@
+package com.j256.ormlite.field.types;
+
+import static org.junit.Assert.*;
+
+public class OffsetTimeTypeTest {
+
+}

--- a/src/test/java/com/j256/ormlite/h2/H2CompiledStatement.java
+++ b/src/test/java/com/j256/ormlite/h2/H2CompiledStatement.java
@@ -98,6 +98,16 @@ public class H2CompiledStatement implements CompiledStatement {
 				return Types.LONGVARCHAR;
 			case DATE:
 				return Types.TIMESTAMP;
+			case LOCAL_DATE:
+				return Types.DATE;
+			case LOCAL_TIME:
+				return Types.TIME;
+			case LOCAL_DATE_TIME:
+				return Types.TIMESTAMP;
+			case OFFSET_TIME:
+				return Types.TIME_WITH_TIMEZONE;
+			case OFFSET_DATE_TIME:
+				return Types.TIMESTAMP_WITH_TIMEZONE;
 			case BOOLEAN:
 				return Types.BOOLEAN;
 			case CHAR:

--- a/src/test/java/com/j256/ormlite/h2/H2DatabaseResults.java
+++ b/src/test/java/com/j256/ormlite/h2/H2DatabaseResults.java
@@ -3,11 +3,7 @@ package com.j256.ormlite.h2;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
-import java.sql.Blob;
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.SQLException;
-import java.sql.Timestamp;
+import java.sql.*;
 import java.time.*;
 
 import com.j256.ormlite.dao.ObjectCache;
@@ -148,6 +144,16 @@ public class H2DatabaseResults implements DatabaseResults {
 	@Override
 	public Timestamp getTimestamp(int columnIndex) throws SQLException {
 		return resultSet.getTimestamp(columnIndex + 1);
+	}
+
+	@Override
+	public Time getTime(int columnIndex) throws SQLException {
+		return resultSet.getTime(columnIndex + 1);
+	}
+
+	@Override
+	public Date getDate(int columnIndex) throws SQLException {
+		return resultSet.getDate(columnIndex + 1);
 	}
 
 	@Override

--- a/src/test/java/com/j256/ormlite/h2/H2DatabaseResults.java
+++ b/src/test/java/com/j256/ormlite/h2/H2DatabaseResults.java
@@ -8,6 +8,7 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.time.*;
 
 import com.j256.ormlite.dao.ObjectCache;
 import com.j256.ormlite.misc.IOUtils;
@@ -147,6 +148,31 @@ public class H2DatabaseResults implements DatabaseResults {
 	@Override
 	public Timestamp getTimestamp(int columnIndex) throws SQLException {
 		return resultSet.getTimestamp(columnIndex + 1);
+	}
+
+	@Override
+	public LocalDate getLocalDate(int columnIndex) throws SQLException {
+		return resultSet.getObject(columnIndex + 1, LocalDate.class);
+	}
+
+	@Override
+	public LocalTime getLocalTime(int columnIndex) throws SQLException {
+		return resultSet.getObject(columnIndex + 1, LocalTime.class);
+	}
+
+	@Override
+	public LocalDateTime getLocalDateTime(int columnIndex) throws SQLException {
+		return resultSet.getObject(columnIndex + 1, LocalDateTime.class);
+	}
+
+	@Override
+	public OffsetTime getOffsetTime(int columnIndex) throws SQLException {
+		return resultSet.getObject(columnIndex + 1, OffsetTime.class);
+	}
+
+	@Override
+	public OffsetDateTime getOffsetDateTime(int columnIndex) throws SQLException {
+		return resultSet.getObject(columnIndex + 1, OffsetDateTime.class);
 	}
 
 	@Override

--- a/src/test/java/com/j256/ormlite/h2/H2DatabaseType.java
+++ b/src/test/java/com/j256/ormlite/h2/H2DatabaseType.java
@@ -55,6 +55,11 @@ public class H2DatabaseType extends BaseDatabaseType {
 	}
 
 	@Override
+	public void appendOffsetTimeType(StringBuilder sb, FieldType fieldType, int fieldWidth) {
+		sb.append("TIMESTAMP WITH TIME ZONE");
+	}
+
+	@Override
 	protected void configureGeneratedId(String tableName, StringBuilder sb, FieldType fieldType,
 			List<String> statementsBefore, List<String> statementsAfter, List<String> additionalArgs,
 			List<String> queriesAfter) {

--- a/src/test/java/com/j256/ormlite/h2/H2DatabaseType.java
+++ b/src/test/java/com/j256/ormlite/h2/H2DatabaseType.java
@@ -5,10 +5,7 @@ import java.sql.SQLException;
 import java.util.List;
 
 import com.j256.ormlite.db.BaseDatabaseType;
-import com.j256.ormlite.field.DataPersister;
-import com.j256.ormlite.field.DataType;
-import com.j256.ormlite.field.FieldConverter;
-import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.field.*;
 import com.j256.ormlite.field.types.OffsetTimeType;
 
 /**
@@ -79,7 +76,7 @@ public class H2DatabaseType extends BaseDatabaseType {
 	@Override
 	public FieldConverter getFieldConverter(DataPersister dataPersister, FieldType fieldType) {
 		// H2 doesn't support TIME WITH TIME ZONE
-		if (fieldType.getDataPersister() instanceof OffsetTimeType)
+		if (dataPersister.getSqlType() == SqlType.OFFSET_TIME)
 			return DataType.OFFSET_TIME_SQL.getDataPersister();
 		// default is to use the dataPersister itself
 		return dataPersister;

--- a/src/test/java/com/j256/ormlite/h2/H2DatabaseType.java
+++ b/src/test/java/com/j256/ormlite/h2/H2DatabaseType.java
@@ -5,7 +5,11 @@ import java.sql.SQLException;
 import java.util.List;
 
 import com.j256.ormlite.db.BaseDatabaseType;
+import com.j256.ormlite.field.DataPersister;
+import com.j256.ormlite.field.DataType;
+import com.j256.ormlite.field.FieldConverter;
 import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.field.types.OffsetTimeType;
 
 /**
  * H2 database type.
@@ -70,5 +74,14 @@ public class H2DatabaseType extends BaseDatabaseType {
 	@Override
 	public boolean isCreateIfNotExistsSupported() {
 		return true;
+	}
+
+	@Override
+	public FieldConverter getFieldConverter(DataPersister dataPersister, FieldType fieldType) {
+		// H2 doesn't support TIME WITH TIME ZONE
+		if (fieldType.getDataPersister() instanceof OffsetTimeType)
+			return DataType.OFFSET_TIME_SQL.getDataPersister();
+		// default is to use the dataPersister itself
+		return dataPersister;
 	}
 }


### PR DESCRIPTION
Hopefully closes #154 

Adds support for Java 8 Time API (JSR-310), specifically for `LocalDate`, `LocalTime`, `LocalDateTime`, `OffsetTime`, `OffsetDateTime` and `Instant`.

Default persisters use JDBC 4.2 API and pass values without conversion.

For DBs that don't fully support 4.2 (H2 and PostgreSQL don't support `TIME WITH TIME ZONE`, but support `TIMESTAMP WITH TIME ZONE`) there's a secondary persister for `OffsetTime` that converts `OffsetTime` to `OffsetDateTime` with date part fixed at epoch. There's an overriden `FieldConverter` for those DBs in ormlite-jdbc, but these persisters can also be enabled by specifying `DataType` in annotation of the Dao class. 
`Instant` is not a part of 4.2 API, so it converts to/from `OffsetDateTime`.
For `LocalDate|Time` classes there are also secondary persisters, that convert java.time values to java.sql values using methods, added in Java 8. These are, again, forced in overriden 'FieldConverter's for those DBs in ormlite-jdbc and can also be enabled by specifying `DataType`. Someone with a better knowledge of DBs than me should take a look at those, since finding anything concrete in the documentation for all those different DBs is a pain (I presume DB2 and Netezza don't support 4.2, but I'm still not sure. Same for Sqlite).

For every persister there's a check in `getSingleton()` method that returns `null`, if there's no corresponding java.time class in classpath to allow compiling for older JDKs. No actual testing was done for that though.

I am not entirely clear on purpose of `isArgumentHolderRequired()` and `moveToNextValue()` methods of `BaseData`, so I aped those off of `DateType` (aped the tests as well). 

New tests will fail for H2 1.2.128, since that version doesn't support 4.2 yet. For the latest H2 (1.4.197) they pass. However, old tests begin to fail, due to some changes in API, though this does not affect this PR, and I will create a separate issue for that. 