### PR TITLE
Fixed default width not being applied for BigInteger

### DIFF
--- a/src/main/java/com/j256/ormlite/field/types/BigIntegerType.java
+++ b/src/main/java/com/j256/ormlite/field/types/BigIntegerType.java
@@ -88,4 +88,9 @@ public class BigIntegerType extends BaseDataType {
 	public boolean isValidForVersion() {
 		return true;
 	}
+
+	@Override
+	public int getDefaultWidth() {
+		return DEFAULT_WIDTH;
+	}
 }


### PR DESCRIPTION
This would error on databases which did not accept `VARCHAR(0)`.