### PR TITLE
Fixed a couple of incorrect SqlTypes in field converters

### DIFF
--- a/src/main/java/com/j256/ormlite/db/BaseDatabaseType.java
+++ b/src/main/java/com/j256/ormlite/db/BaseDatabaseType.java
@@ -619,7 +619,7 @@ public abstract class BaseDatabaseType implements DatabaseType {
 	protected static class BooleanNumberFieldConverter extends BaseFieldConverter {
 		@Override
 		public SqlType getSqlType() {
-			return SqlType.BOOLEAN;
+			return SqlType.BYTE;
 		}
 
 		@Override

--- a/src/main/java/com/j256/ormlite/field/types/BooleanCharType.java
+++ b/src/main/java/com/j256/ormlite/field/types/BooleanCharType.java
@@ -31,7 +31,7 @@ public class BooleanCharType extends BooleanType {
 	}
 
 	public BooleanCharType() {
-		super(SqlType.STRING);
+		super(SqlType.CHAR);
 	}
 
 	@Override

--- a/src/test/java/com/j256/ormlite/db/BaseCoreDatabaseTypeTest.java
+++ b/src/test/java/com/j256/ormlite/db/BaseCoreDatabaseTypeTest.java
@@ -226,7 +226,7 @@ public class BaseCoreDatabaseTypeTest extends BaseCoreTest {
 
 	@Test
 	public void testBooleanConverterGetSqlType() {
-		assertEquals(SqlType.BOOLEAN, booleanFieldConverter.getSqlType());
+		assertEquals(SqlType.BYTE, booleanFieldConverter.getSqlType());
 	}
 
 	@Test


### PR DESCRIPTION
Two fixes. The most important I'd say is the first one.

1. **BooleanNumberFieldConverter**: The purpose of this was to convert a boolean to a number, but the class declares it is storing a boolean! This caused exceptions with its use in Derby.
SQLite, which I imagine is what this was originally made for, seemed to cope okay with it in its JDBC driver. I don't believe this is going to cause any issues since `BOOLEAN` maps to `NUMERIC` in SQLite which means "any type" over there. I have not tested Android, sorry, but I would be surprised if there were issues there.

2. **BooleanCharType**: the purpose of this class is to convert to a `CHAR` rather than a `VARCHAR`. The few JDBC drivers I've looked at work with char and String in either type so it didn't cause really any driver-level issues before. However, some DBs may error with the use of `VARCHAR(0)`, similar to #160.
Out-of-the-box, this was only used in Oracle, but its implementation of it was broken anyway (PR with a fix is coming soon).

Let me know if there are any concerns with these changes.