### PR TITLE
Moved makeConfigObject up to FieldConverter interface

### DIFF
--- a/src/main/java/com/j256/ormlite/field/BaseFieldConverter.java
+++ b/src/main/java/com/j256/ormlite/field/BaseFieldConverter.java
@@ -45,4 +45,9 @@ public abstract class BaseFieldConverter implements FieldConverter {
 	public boolean isStreamType() {
 		return false;
 	}
+
+	@Override
+	public Object makeConfigObject(FieldType fieldType) throws SQLException {
+		return null;
+	}
 }

--- a/src/main/java/com/j256/ormlite/field/DataPersister.java
+++ b/src/main/java/com/j256/ormlite/field/DataPersister.java
@@ -30,12 +30,6 @@ public interface DataPersister extends FieldConverter {
 	public String[] getAssociatedClassNames();
 
 	/**
-	 * This makes a configuration object for the data-type or returns null if none. The object can be accessed later via
-	 * {@link FieldType#getDataTypeConfigObj()}.
-	 */
-	public Object makeConfigObject(FieldType fieldType) throws SQLException;
-
-	/**
 	 * Convert a {@link Number} object to its primitive object suitable for assigning to a java ID field.
 	 */
 	public Object convertIdNumber(Number number);

--- a/src/main/java/com/j256/ormlite/field/FieldConverter.java
+++ b/src/main/java/com/j256/ormlite/field/FieldConverter.java
@@ -72,4 +72,13 @@ public interface FieldConverter {
 	 * Convert a string result value to the related Java field.
 	 */
 	public Object resultStringToJava(FieldType fieldType, String stringValue, int columnPos) throws SQLException;
+
+	/**
+	 * This makes a configuration object for the data-type or returns null if none. The object can be accessed later via
+	 * {@link FieldType#getDataTypeConfigObj()}.
+	 *
+	 * @throws SQLException
+	 *             If there are problems creating the config object. Needed for subclasses.
+	 */
+	public Object makeConfigObject(FieldType fieldType) throws SQLException;
 }

--- a/src/main/java/com/j256/ormlite/field/FieldType.java
+++ b/src/main/java/com/j256/ormlite/field/FieldType.java
@@ -1147,7 +1147,7 @@ public class FieldType {
 			throw new SQLException("Field '" + field.getName() + "' is of data type " + dataPersister
 					+ " which cannot be the ID field");
 		}
-		this.dataTypeConfigObj = dataPersister.makeConfigObject(this);
+		this.dataTypeConfigObj = fieldConverter.makeConfigObject(this);
 		String defaultStr = fieldConfig.getDefaultValue();
 		if (defaultStr == null) {
 			this.defaultValue = null;

--- a/src/main/java/com/j256/ormlite/field/types/BaseDataType.java
+++ b/src/main/java/com/j256/ormlite/field/types/BaseDataType.java
@@ -80,15 +80,6 @@ public abstract class BaseDataType extends BaseFieldConverter implements DataPer
 		}
 	}
 
-	/**
-	 * @throws SQLException
-	 *             If there are problems creating the config object. Needed for subclasses.
-	 */
-	@Override
-	public Object makeConfigObject(FieldType fieldType) throws SQLException {
-		return null;
-	}
-
 	@Override
 	public SqlType getSqlType() {
 		return sqlType;


### PR DESCRIPTION
`makeConfigObject` is what fills `dataTypeConfigObj` in `FieldType`. Looking at the use of `getDataTypeConfigObj()` in ORMLite's default data persisters, it is exclusively used within `FieldConverter` methods. Therefore, I believe it is more appropriate for the config object to be a part of the `FieldConverter`.

In practice this makes an important fix. Now the result of `getFieldConverter()` is used to create the config object. A real world scenario where this was critical is [in Oracle](https://github.com/j256/ormlite-jdbc/blob/f11ffef98649d32ad70d1a78ed14b194b6f30c91/src/main/java/com/j256/ormlite/db/OracleDatabaseType.java#L103). `BooleanCharType` contains a `makeConfigObject` but it would never be called in this scenario without the change in this pull request.