### PR TITLE
Fixed transaction level counter not always being decremented

### DIFF
--- a/src/main/java/com/j256/ormlite/misc/TransactionManager.java
+++ b/src/main/java/com/j256/ormlite/misc/TransactionManager.java
@@ -235,9 +235,10 @@ public class TransactionManager {
 			try {
 				levelCount.incrementAndGet();
 				T result = callable.call();
+				int level = levelCount.decrementAndGet();
 				if (hasSavePoint) {
 					// only commit if we have reached the end of our transaction stack
-					if (levelCount.decrementAndGet() <= 0) {
+					if (level <= 0) {
 						commit(connection, savePoint);
 						transactionLevelThreadLocal.remove();
 					} else {


### PR DESCRIPTION
If we are in a nested transaction and `isNestedSavePointsSupported()` is false, then `hasSavePoint` will be false which would mean, barring further exceptions, the `levelCount` is never decremented! This is a simple fix to make sure it always is.