### PR TITLE
Moved from using RETURN_GENERATED_KEYS to named columns

### DIFF
--- a/src/main/java/com/j256/ormlite/stmt/mapped/MappedCreate.java
+++ b/src/main/java/com/j256/ormlite/stmt/mapped/MappedCreate.java
@@ -54,7 +54,7 @@ public class MappedCreate<T, ID> extends BaseMappedStatement<T, ID> {
 			} else if (idField.isGeneratedId()) {
 				if (assignId) {
 					// get the id back from the database
-					keyHolder = new KeyHolder();
+					keyHolder = new KeyHolder(idField.getColumnName());
 				}
 			} else {
 				// the id should have been set by the caller already
@@ -257,7 +257,17 @@ public class MappedCreate<T, ID> extends BaseMappedStatement<T, ID> {
 	}
 
 	private static class KeyHolder implements GeneratedKeyHolder {
+		String columnName;
 		Number key;
+
+		public KeyHolder(String columnName) {
+			this.columnName = columnName;
+		}
+
+		@Override
+		public String getColumnName() {
+			return this.columnName;
+		}
 
 		public Number getKey() {
 			return key;

--- a/src/main/java/com/j256/ormlite/support/GeneratedKeyHolder.java
+++ b/src/main/java/com/j256/ormlite/support/GeneratedKeyHolder.java
@@ -10,6 +10,11 @@ import java.sql.SQLException;
 public interface GeneratedKeyHolder {
 
 	/**
+	 * Return the name of the generated column we are interested in.
+	 */
+	public String getColumnName();
+
+	/**
 	 * Add the key number on the key holder. May be called multiple times.
 	 */
 	public void addKey(Number key) throws SQLException;

--- a/src/test/java/com/j256/ormlite/h2/H2DatabaseConnection.java
+++ b/src/test/java/com/j256/ormlite/h2/H2DatabaseConnection.java
@@ -105,7 +105,7 @@ public class H2DatabaseConnection implements DatabaseConnection {
 		if (keyHolder == null) {
 			stmt = connection.prepareStatement(statement);
 		} else {
-			stmt = connection.prepareStatement(statement, Statement.RETURN_GENERATED_KEYS);
+			stmt = connection.prepareStatement(statement, new String[] { keyHolder.getColumnName() });
 		}
 		statementSetArgs(stmt, args, argFieldTypes);
 		int rowN = stmt.executeUpdate();


### PR DESCRIPTION
`Statement.RETURN_GENERATED_KEYS` is a poorly defined standard. Different JDBC drivers interpret it differently so its behaviour can, and does, differ.

The best example of this is PostgreSQL and modern H2 drivers where this flag will still return rows which have a column generated, but the result set contains _all_ columns. Meanwhile over in SQL Server, it returns a pseudocolumn and not a real column so even filtering the result set will not work there.

So instead we explicitly declare which column we want which works a lot better for compatibility between drivers.