### PR TITLE
Move the log4j classes to core.  Thanks to @MarcMil.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,9 @@
 		<commons-lang-version>2.1</commons-lang-version>
 		<commons-logging-version>1.1.1</commons-logging-version>
 		<slf4j-version>1.7.2</slf4j-version>
+		<!-- yes we know this is an issue but it is here for backwards compatibility -->
+		<log4j-version>1.2.17</log4j-version>
+		<log4j2-version>2.0-beta4</log4j2-version>
 	</properties>
 	<profiles>
 		<profile>
@@ -388,6 +391,18 @@
 			<groupId>commons-logging</groupId>
 			<artifactId>commons-logging</artifactId>
 			<version>${commons-logging-version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>log4j</groupId>
+			<artifactId>log4j</artifactId>
+			<version>${log4j-version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>${log4j2-version}</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/src/main/java/com/j256/ormlite/logger/Log4j2Log.java
+++ b/src/main/java/com/j256/ormlite/logger/Log4j2Log.java
@@ -1,0 +1,91 @@
+package com.j256.ormlite.logger;
+
+import com.j256.ormlite.logger.Log;
+
+/**
+ * Class which implements our {@link com.j256.ormlite.logger.Log} interface by delegating to Apache Log4j2.
+ * 
+ * @author graywatson
+ */
+public class Log4j2Log implements Log {
+
+	private final org.apache.logging.log4j.Logger logger;
+
+	public Log4j2Log(String className) {
+		this.logger = org.apache.logging.log4j.LogManager.getLogger(className);
+	}
+
+	@Override
+	public boolean isLevelEnabled(Level level) {
+		switch (level) {
+			case TRACE:
+				return logger.isTraceEnabled();
+			case DEBUG:
+				return logger.isDebugEnabled();
+			case INFO:
+				return logger.isInfoEnabled();
+			case WARNING:
+				return logger.isWarnEnabled();
+			case ERROR:
+				return logger.isErrorEnabled();
+			case FATAL:
+				return logger.isFatalEnabled();
+			default:
+				return logger.isInfoEnabled();
+		}
+	}
+
+	@Override
+	public void log(Level level, String msg) {
+		switch (level) {
+			case TRACE:
+				logger.trace(msg);
+				break;
+			case DEBUG:
+				logger.debug(msg);
+				break;
+			case INFO:
+				logger.info(msg);
+				break;
+			case WARNING:
+				logger.warn(msg);
+				break;
+			case ERROR:
+				logger.error(msg);
+				break;
+			case FATAL:
+				logger.fatal(msg);
+				break;
+			default:
+				logger.info(msg);
+				break;
+		}
+	}
+
+	@Override
+	public void log(Level level, String msg, Throwable t) {
+		switch (level) {
+			case TRACE:
+				logger.trace(msg, t);
+				break;
+			case DEBUG:
+				logger.debug(msg, t);
+				break;
+			case INFO:
+				logger.info(msg, t);
+				break;
+			case WARNING:
+				logger.warn(msg, t);
+				break;
+			case ERROR:
+				logger.error(msg, t);
+				break;
+			case FATAL:
+				logger.fatal(msg, t);
+				break;
+			default:
+				logger.info(msg, t);
+				break;
+		}
+	}
+}

--- a/src/main/java/com/j256/ormlite/logger/Log4jLog.java
+++ b/src/main/java/com/j256/ormlite/logger/Log4jLog.java
@@ -1,0 +1,51 @@
+package com.j256.ormlite.logger;
+
+import com.j256.ormlite.logger.Log;
+
+/**
+ * Class which implements our {@link com.j256.ormlite.logger.Log} interface by delegating to Apache Log4j.
+ * 
+ * @author graywatson
+ */
+public class Log4jLog implements Log {
+
+	private final org.apache.log4j.Logger logger;
+
+	public Log4jLog(String className) {
+		this.logger = org.apache.log4j.Logger.getLogger(className);
+	}
+
+	@Override
+	public boolean isLevelEnabled(Level level) {
+		return logger.isEnabledFor(levelToLog4jLevel(level));
+	}
+
+	@Override
+	public void log(Level level, String msg) {
+		logger.log(levelToLog4jLevel(level), msg);
+	}
+
+	@Override
+	public void log(Level level, String msg, Throwable t) {
+		logger.log(levelToLog4jLevel(level), msg, t);
+	}
+
+	private org.apache.log4j.Level levelToLog4jLevel(com.j256.ormlite.logger.Log.Level level) {
+		switch (level) {
+			case TRACE:
+				return org.apache.log4j.Level.TRACE;
+			case DEBUG:
+				return org.apache.log4j.Level.DEBUG;
+			case INFO:
+				return org.apache.log4j.Level.INFO;
+			case WARNING:
+				return org.apache.log4j.Level.WARN;
+			case ERROR:
+				return org.apache.log4j.Level.ERROR;
+			case FATAL:
+				return org.apache.log4j.Level.FATAL;
+			default:
+				return org.apache.log4j.Level.INFO;
+		}
+	}
+}

--- a/src/main/javadoc/doc-files/changelog.txt
+++ b/src/main/javadoc/doc-files/changelog.txt
@@ -9,6 +9,7 @@
 	* JDBC: Update the DB2 driver class.  Thanks to mauro-palumbo.
 	* JDBC: Added support for create table if not exists for HSQLDB versions 2.3.X and greater.  Thanks to lukewhitt.
 	* JDBC: Fixed a problem with H2's handling of boolean fields.
+	* JDBC: Fixed the log4j logger classes broken in 5.2.  Also moved them over to core.  Thanks to MarcMil.
 
 5.2: 11/14/2020
 	* JDBC: Refactored the JDBC package to make it java9 compliant by moving all classes under jdbc subpackage.

--- a/src/test/java/com/j256/ormlite/logger/Log4jLogTest.java
+++ b/src/test/java/com/j256/ormlite/logger/Log4jLogTest.java
@@ -1,0 +1,8 @@
+package com.j256.ormlite.logger;
+
+public class Log4jLogTest extends BaseLogTest {
+
+	public Log4jLogTest() {
+		super(new Log4jLog("Log4jLogTest"));
+	}
+}

--- a/src/test/java/com/j256/ormlite/logger/LoggerFactoryTest.java
+++ b/src/test/java/com/j256/ormlite/logger/LoggerFactoryTest.java
@@ -34,7 +34,8 @@ public class LoggerFactoryTest {
 	public void testLogTypeIsAvailable() {
 		assertFalse(LoggerFactory.LogType.ANDROID.isAvailable());
 		assertTrue(LoggerFactory.LogType.COMMONS_LOGGING.isAvailable());
-		assertFalse(LoggerFactory.LogType.LOG4J.isAvailable());
+		assertTrue(LoggerFactory.LogType.LOG4J.isAvailable());
+		assertTrue(LoggerFactory.LogType.LOG4J2.isAvailable());
 		assertTrue(LoggerFactory.LogType.LOCAL.isAvailable());
 		assertTrue(LoggerFactory.LogType.LOCAL.isAvailableTestClass());
 	}
@@ -48,9 +49,9 @@ public class LoggerFactoryTest {
 		log = LoggerFactory.LogType.COMMONS_LOGGING.createLog(getClass().getName());
 		assertTrue(log instanceof CommonsLoggingLog);
 		log = LoggerFactory.LogType.LOG4J.createLog(getClass().getName());
-		assertTrue(log instanceof LocalLog);
-		log = LoggerFactory.LogType.LOG4J.createLog(getClass().getName());
-		assertTrue(log instanceof LocalLog);
+		assertTrue(log instanceof Log4jLog);
+		log = LoggerFactory.LogType.LOG4J2.createLog(getClass().getName());
+		assertTrue(log instanceof Log4j2Log);
 		log = LoggerFactory.LogType.LOCAL.createLog(getClass().getName());
 		assertTrue(log instanceof LocalLog);
 		log = LoggerFactory.LogType.LOCAL.createLog(getClass().getName());


### PR DESCRIPTION
Also fixed a problem with the wiring of the log4j that would cause them to not be found.