### PR TITLE
Fix flasky1

### DIFF
--- a/src/test/java/com/j256/ormlite/field/FieldTypeTest.java
+++ b/src/test/java/com/j256/ormlite/field/FieldTypeTest.java
@@ -21,7 +21,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
-
+import java.util.Arrays;
+import java.util.Comparator;
 import org.junit.Test;
 
 import com.j256.ormlite.BaseCoreTest;
@@ -439,8 +440,17 @@ public class FieldTypeTest extends BaseCoreTest {
 	@Test
 	public void testAssignForeign() throws Exception {
 		Field[] fields = ForeignParent.class.getDeclaredFields();
+		Field[] sortedfields = ForeignParent.class.getDeclaredFields();
+		Arrays.sort(sortedfields, new Comparator<Field>() {
+			public int compare(Field a, Field b) {
+				return a.getName().compareTo(b.getName());
+			}
+		});
+		fields = sortedfields;
+
 		assertTrue(fields.length >= 3);
-		Field field = fields[2];
+		Field field = fields[0];
+
 		FieldType fieldType = FieldType.createFieldType(databaseType, ForeignParent.class.getSimpleName(), field,
 				ForeignParent.class);
 		fieldType.configDaoInformation(connectionSource, ForeignParent.class);

--- a/src/test/java/com/j256/ormlite/field/FieldTypeTest.java
+++ b/src/test/java/com/j256/ormlite/field/FieldTypeTest.java
@@ -48,11 +48,18 @@ public class FieldTypeTest extends BaseCoreTest {
 	public void testFieldType() throws Exception {
 
 		Field[] fields = LocalFoo.class.getDeclaredFields();
+		Arrays.sort(fields, new Comparator<Field>() {
+			public int compare(Field a, Field b) {
+				if (a.isSynthetic()) return 1;
+				if (b.isSynthetic()) return -1;
+				return a.getName().compareTo(b.getName());
+			}
+		});
 		assertTrue(fields.length >= 4);
-		Field nameField = fields[0];
-		Field rankField = fields[1];
-		Field serialField = fields[2];
-		Field intLongField = fields[3];
+		Field nameField = fields[1];
+		Field rankField = fields[2];
+		Field serialField = fields[3];
+		Field intLongField = fields[0];
 
 		FieldType fieldType =
 				FieldType.createFieldType(databaseType, LocalFoo.class.getSimpleName(), nameField, LocalFoo.class);
@@ -147,9 +154,16 @@ public class FieldTypeTest extends BaseCoreTest {
 
 	@Test
 	public void testFieldTypeConverter() throws Exception {
-		Field[] fields = LocalFoo.class.getDeclaredFields();
+		Field[] fields = LocalFoo.class.getDeclaredFields();		
+		Arrays.sort(fields, new Comparator<Field>() {
+			public int compare(Field a, Field b) {
+				if (a.isSynthetic()) return 1;
+				if (b.isSynthetic()) return -1;
+				return a.getName().compareTo(b.getName());
+			}
+		});
 		assertTrue(fields.length >= 4);
-		Field nameField = fields[0];
+		Field nameField = fields[1];
 		DatabaseType databaseType = createMock(DatabaseType.class);
 		final SqlType sqlType = SqlType.DATE;
 		final String nameArg = "zippy buzz";
@@ -217,11 +231,18 @@ public class FieldTypeTest extends BaseCoreTest {
 	public void testFieldForeign() throws Exception {
 
 		Field[] fields = ForeignParent.class.getDeclaredFields();
+		Arrays.sort(fields, new Comparator<Field>() {
+			public int compare(Field a, Field b) {
+				if (a.isSynthetic()) return 1;
+				if (b.isSynthetic()) return -1;
+				return a.getName().compareTo(b.getName());
+			}
+		});
 		assertTrue(fields.length >= 3);
 		@SuppressWarnings("unused")
-		Field idField = fields[0];
-		Field nameField = fields[1];
-		Field bazField = fields[2];
+		Field idField = fields[1];
+		Field nameField = fields[2];
+		Field bazField = fields[0];
 
 		FieldType fieldType = FieldType.createFieldType(databaseType, ForeignParent.class.getSimpleName(), nameField,
 				ForeignParent.class);
@@ -391,8 +412,15 @@ public class FieldTypeTest extends BaseCoreTest {
 	@Test
 	public void testSetValueField() throws Exception {
 		Field[] fields = LocalFoo.class.getDeclaredFields();
+		Arrays.sort(fields, new Comparator<Field>() {
+			public int compare(Field a, Field b) {
+				if (a.isSynthetic()) return 1;
+				if (b.isSynthetic()) return -1;
+				return a.getName().compareTo(b.getName());
+			}
+		});
 		assertTrue(fields.length >= 4);
-		Field nameField = fields[0];
+		Field nameField = fields[1];
 		FieldType fieldType =
 				FieldType.createFieldType(databaseType, LocalFoo.class.getSimpleName(), nameField, LocalFoo.class);
 		LocalFoo foo = new LocalFoo();
@@ -417,8 +445,15 @@ public class FieldTypeTest extends BaseCoreTest {
 	@Test(expected = SQLException.class)
 	public void testSetIdFieldString() throws Exception {
 		Field[] fields = LocalFoo.class.getDeclaredFields();
+		Arrays.sort(fields, new Comparator<Field>() {
+			public int compare(Field a, Field b) {
+				if (a.isSynthetic()) return 1;
+				if (b.isSynthetic()) return -1;
+				return a.getName().compareTo(b.getName());
+			}
+		});
 		assertTrue(fields.length >= 4);
-		Field nameField = fields[0];
+		Field nameField = fields[1];
 		FieldType fieldType =
 				FieldType.createFieldType(databaseType, LocalFoo.class.getSimpleName(), nameField, LocalFoo.class);
 		fieldType.assignIdValue(connectionSource, new LocalFoo(), 10, null);
@@ -427,6 +462,14 @@ public class FieldTypeTest extends BaseCoreTest {
 	@Test
 	public void testCanBeNull() throws Exception {
 		Field[] fields = CanBeNull.class.getDeclaredFields();
+
+		Arrays.sort(fields, new Comparator<Field>() {
+			public int compare(Field a, Field b) {
+				if (a.isSynthetic()) return 1;
+				if (b.isSynthetic()) return -1;
+				return a.getName().compareTo(b.getName());
+			}
+		});
 		assertTrue(fields.length >= 2);
 		Field field = fields[0];
 		FieldType fieldType =
@@ -440,15 +483,14 @@ public class FieldTypeTest extends BaseCoreTest {
 	@Test
 	public void testAssignForeign() throws Exception {
 		Field[] fields = ForeignParent.class.getDeclaredFields();
-		Field[] sortedfields = ForeignParent.class.getDeclaredFields();
-		Arrays.sort(sortedfields, new Comparator<Field>() {
+		
+		Arrays.sort(fields, new Comparator<Field>() {
 			public int compare(Field a, Field b) {
+				if (a.isSynthetic()) return 1;
+				if (b.isSynthetic()) return -1;
 				return a.getName().compareTo(b.getName());
 			}
 		});
-		fields = sortedfields;
-
-		assertTrue(fields.length >= 3);
 		Field field = fields[0];
 
 		FieldType fieldType = FieldType.createFieldType(databaseType, ForeignParent.class.getSimpleName(), field,
@@ -480,6 +522,13 @@ public class FieldTypeTest extends BaseCoreTest {
 	public void testGeneratedIdDefaultValue() throws Exception {
 		Class<GeneratedIdDefault> clazz = GeneratedIdDefault.class;
 		Field[] fields = clazz.getDeclaredFields();
+		Arrays.sort(fields, new Comparator<Field>() {
+			public int compare(Field a, Field b) {
+				if (a.isSynthetic()) return 1;
+				if (b.isSynthetic()) return -1;
+				return a.getName().compareTo(b.getName());
+			}
+		});
 		assertTrue(fields.length >= 1);
 		Field idField = fields[0];
 		FieldType.createFieldType(databaseType, clazz.getSimpleName(), idField, clazz);
@@ -489,6 +538,13 @@ public class FieldTypeTest extends BaseCoreTest {
 	public void testThrowIfNullNotPrimitive() throws Exception {
 		Class<ThrowIfNullNonPrimitive> clazz = ThrowIfNullNonPrimitive.class;
 		Field[] fields = clazz.getDeclaredFields();
+		Arrays.sort(fields, new Comparator<Field>() {
+			public int compare(Field a, Field b) {
+				if (a.isSynthetic()) return 1;
+				if (b.isSynthetic()) return -1;
+				return a.getName().compareTo(b.getName());
+			}
+		});
 		assertTrue(fields.length >= 1);
 		Field field = fields[0];
 		FieldType.createFieldType(databaseType, clazz.getSimpleName(), field, clazz);


### PR DESCRIPTION
the test create fieldType from a static class ForeignParent and the assert fieldType.isForeign() is failed with nondex. This is because getDeclaredFields() is not deterministic with the order of returned field array, and the original test directly goes Field field = fields[2]; which is certainly not deterministic although foreign is actually at the third position in definition.
This PR proposes to sort the returned fields to make it deterministic.

The same thing happen for testAssignForeign, testCanBeNull, testFieldForeign, testFieldType, testFieldTypeConverter, testGeneratedIdDefaultValue, testSetIdFieldString, testSetValueField, testThrowIfNullNotPrimitive. So the fixes for them are almost same. The new index of visited elements are carefully changed.