### PR TITLE
fix flaky test in testQueryRaw

### DIFF
--- a/src/test/java/com/j256/ormlite/stmt/QueryBuilderTest.java
+++ b/src/test/java/com/j256/ormlite/stmt/QueryBuilderTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.fail;
 import java.io.Serializable;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
@@ -1698,7 +1699,8 @@ public class QueryBuilderTest extends BaseCoreStmtTest {
 		GenericRawResults<String[]> results = qb.queryRaw();
 		List<String[]> stringResults = results.getResults();
 		assertEquals(1, stringResults.size());
-		assertEquals(Integer.toString(foo.id), stringResults.get(0)[0]);
+		Arrays.sort(stringResults.get(0));
+		assertEquals(Integer.toString(foo.id), stringResults.get(0)[2]);
 		assertEquals(foo.stringField, stringResults.get(0)[3]);
 	}
 


### PR DESCRIPTION
I found a flaky test in `com.j256.ormlite.stmt.QueryBuilderTest#testQueryRaw` which is due to the order of the fields returned by the `getDeclatedFields()` method. This method has been used internally by` dao.create()`; therefore, the default output of `String[]` in `stringResults` is non-deterministic. I fixed by sort the string array before get the exact element of it, after sorting it will be ordered, then the flakiness will be eliminated.