### PR TITLE
fix flaky test in DatabaseConnectionProxyFactoryTest

### DIFF
--- a/src/test/java/com/j256/ormlite/support/DatabaseConnectionProxyFactoryTest.java
+++ b/src/test/java/com/j256/ormlite/support/DatabaseConnectionProxyFactoryTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.AfterClass;
 import org.junit.Test;
@@ -101,7 +103,11 @@ public class DatabaseConnectionProxyFactoryTest extends BaseCoreTest {
 		public int insert(String statement, Object[] args, FieldType[] argfieldTypes, GeneratedKeyHolder keyHolder)
 				throws SQLException {
 			// just record the first argument to the insert which for Foo should be the 'val' field
-			lastValue = (Integer) args[0];
+			Map<String, Object> columnName2val = new HashMap<String, Object>();
+			for (int i = 0; i < argfieldTypes.length; ++i) {
+				columnName2val.put(argfieldTypes[i].getColumnName(), args[i]);
+			}
+			lastValue = (Integer) columnName2val.get("val");
 			if (lastValue == TEST_CHANGE_FROM) {
 				args[0] = TEST_CHANGE_TO;
 			}


### PR DESCRIPTION
In `com.j256.ormlite.support.DatabaseConnectionProxyFactoryTest`, there are two tests, which are `testBasic()` and `testChangeInsertValue()`, both of them are flaky due to the `getDeclaredFields()` non-deterministic [document](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--), which is used by `createDao`. Since the order is no fixed, then the `ConnectionProxy.lastValue` directly equals to the `arg[0]` will cause flakiness. But the order of `args` is consistent with the order of `argfieldTypes`. What I did in order to fix the flakiness is to create a map, and connect the value of column names. Then we could let `ConnectionProxy.lastValue`  equals to the value of column `val` in table `Foo`