### PR TITLE
fix flaky test testAssignForeign in FieldTypeTest

### DIFF
--- a/src/main/java/com/j256/ormlite/misc/VersionUtils.java
+++ b/src/main/java/com/j256/ormlite/misc/VersionUtils.java
@@ -10,7 +10,7 @@ import com.j256.ormlite.logger.LoggerFactory;
  */
 public class VersionUtils {
 
-	private static final String CORE_VERSION = "VERSION__5.7-SNAPSHOT__";
+	private static final String CORE_VERSION = "VERSION__5.6__";
 
 	private static Logger logger;
 	private static boolean thrownOnErrors = false;


### PR DESCRIPTION
Fixed the flakiness in the test `com.j256.ormlite.field.FieldTypeTest.testAssignForeign`. It was flaky because the order of fields the method `getDeclaredFields()` returns is nondeterministic. I sort the Fields[] after I get them, so the name field will always be the third one in the Field[], then I get the name field by using `Field field = fields[2];`.