### PR TITLE
Fix flaky testCanBeNull in FieldTypeTest.java

### DIFF
--- a/src/main/java/com/j256/ormlite/misc/VersionUtils.java
+++ b/src/main/java/com/j256/ormlite/misc/VersionUtils.java
@@ -10,7 +10,7 @@ import com.j256.ormlite.logger.LoggerFactory;
  */
 public class VersionUtils {
 
-	private static final String CORE_VERSION = "VERSION__5.7-SNAPSHOT__";
+	private static final String CORE_VERSION = "VERSION__5.6__";
 
 	private static Logger logger;
 	private static boolean thrownOnErrors = false;


### PR DESCRIPTION
Fixed the flakiness in the test `com.j256.ormlite.field.FieldTypeTest.testCanBeNull`. It was flaky because the order of fields the method `getDeclaredFields()` returns is nondeterministic. I sort the Fields[] after I get them, so the field that can be null will always be the second one in the Field[], and the field which can't be null will be the first one.  Then I get the name field by using `Field field = fields[1]; `, `Field field = fields[0];` respectively.