### PR TITLE
Add lazy variant of Dao#createIfNotExists

### DIFF
--- a/src/main/java/com/j256/ormlite/dao/BaseDaoImpl.java
+++ b/src/main/java/com/j256/ormlite/dao/BaseDaoImpl.java
@@ -373,7 +373,7 @@ public abstract class BaseDaoImpl<T, ID> implements Dao<T, ID> {
 	}
 
 	@Override
-	public synchronized T createIfNotExists(final T data) throws SQLException {
+	public synchronized T createIfNotExists(T data) throws SQLException {
 		if (data == null) {
 			return null;
 		}
@@ -387,13 +387,13 @@ public abstract class BaseDaoImpl<T, ID> implements Dao<T, ID> {
 	}
 
 	@Override
-	public synchronized T createIfNotExists(final ID key, final Supplier<T> entityCreator) throws SQLException {
+	public synchronized T createIfNotExists(ID key, final Supplier<T> entitySupplier) throws SQLException {
 		if (key == null) {
 			return null;
 		}
 		T existing = queryForId(key);
 		if (existing == null) {
-			final T data = entityCreator.get();
+			final T data = entitySupplier.get();
 			create(data);
 			return data;
 		} else {

--- a/src/main/java/com/j256/ormlite/dao/BaseDaoImpl.java
+++ b/src/main/java/com/j256/ormlite/dao/BaseDaoImpl.java
@@ -374,22 +374,26 @@ public abstract class BaseDaoImpl<T, ID> implements Dao<T, ID> {
 
 	@Override
 	public synchronized T createIfNotExists(final T data) throws SQLException {
-		return createIfNotExists(extractId(data), new Supplier<T>() {
-			@Override
-			public T get() {
-				return data;
-			}
-		});
+		if (data == null) {
+			return null;
+		}
+		T existing = queryForSameId(data);
+		if (existing == null) {
+			create(data);
+			return data;
+		} else {
+			return existing;
+		}
 	}
 
 	@Override
-	public synchronized T createIfNotExists(ID key, Supplier<T> dataSupplier) throws SQLException {
+	public synchronized T createIfNotExists(ID key, Supplier<T> entityCreator) throws SQLException {
 		if (key == null) {
 			return null;
 		}
 		T existing = queryForId(key);
 		if (existing == null) {
-			final T data = dataSupplier.get();
+			final T data = entityCreator.get();
 			create(data);
 			return data;
 		} else {

--- a/src/main/java/com/j256/ormlite/dao/BaseDaoImpl.java
+++ b/src/main/java/com/j256/ormlite/dao/BaseDaoImpl.java
@@ -387,7 +387,7 @@ public abstract class BaseDaoImpl<T, ID> implements Dao<T, ID> {
 	}
 
 	@Override
-	public synchronized T createIfNotExists(ID key, Supplier<T> entityCreator) throws SQLException {
+	public synchronized T createIfNotExists(final ID key, final Supplier<T> entityCreator) throws SQLException {
 		if (key == null) {
 			return null;
 		}

--- a/src/main/java/com/j256/ormlite/dao/Dao.java
+++ b/src/main/java/com/j256/ormlite/dao/Dao.java
@@ -31,7 +31,7 @@ import com.j256.ormlite.table.TableInfo;
 /**
  * The definition of the Database Access Objects that handle the reading and writing a class from the database. Kudos to
  * Robert A. for the general concept of this hierarchy.
- * 
+ *
  * @param <T>
  *            The class that the code will be operating on.
  * @param <ID>
@@ -43,7 +43,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 
 	/**
 	 * Retrieves an object associated with a specific ID.
-	 * 
+	 *
 	 * @param id
 	 *            Identifier that matches a specific row in the database to find and return.
 	 * @return The object that has the ID field which equals id or null if no matches.
@@ -56,7 +56,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	 * Query for and return the first item in the object table which matches the PreparedQuery. See
 	 * {@link #queryBuilder()} for more information. This can be used to return the object that matches a single unique
 	 * column. You should use {@link #queryForId(Object)} if you want to query for the id column.
-	 * 
+	 *
 	 * @param preparedQuery
 	 *            Query used to match the objects in the database.
 	 * @return The first object that matches the query.
@@ -68,7 +68,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	/**
 	 * Query for all of the items in the object table. For medium sized or large tables, this may load a lot of objects
 	 * into memory so you should consider using the {@link #iterator()} method instead.
-	 * 
+	 *
 	 * @return A list of all of the objects in the table.
 	 * @throws SQLException
 	 *             on any SQL problems.
@@ -78,7 +78,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	/**
 	 * Query for the first entry in the table returning null if none. This is a convenience method for calling
 	 * queryBuilder().queryForFirst().
-	 * 
+	 *
 	 * @return The first entity in the table or null if none.
 	 * @throws SQLException
 	 *             on any SQL problems.
@@ -88,7 +88,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	/**
 	 * Query for the items in the object table that match a simple where with a single field = value type of WHERE
 	 * clause. This is a convenience method for calling queryBuilder().where().eq(fieldName, value).query().
-	 * 
+	 *
 	 * @return A list of the objects in the table that match the fieldName = value;
 	 * @throws SQLException
 	 *             on any SQL problems.
@@ -148,12 +148,12 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	/**
 	 * Query for the items in the object table which match the prepared query. See {@link #queryBuilder} for more
 	 * information.
-	 * 
+	 *
 	 * <p>
 	 * <b>NOTE:</b> For medium sized or large tables, this may load a lot of objects into memory so you should consider
 	 * using the {@link #iterator(PreparedQuery)} method instead.
 	 * </p>
-	 * 
+	 *
 	 * @param preparedQuery
 	 *            Query used to match the objects in the database.
 	 * @return A list of all of the objects in the table that match the query.
@@ -166,7 +166,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	 * Create a new row in the database from an object. If the object being created uses
 	 * {@link DatabaseField#generatedId()} then the data parameter will be modified and set with the corresponding id
 	 * from the database.
-	 * 
+	 *
 	 * @param data
 	 *            The data item that we are creating in the database.
 	 * @return The number of rows updated in the database. This should be 1.
@@ -176,7 +176,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	/**
 	 * Just like {@link #create(Object)} but with a collection of objects. This will wrap the creates using the same
 	 * mechanism as {@link #callBatchTasks(Callable)}.
-	 * 
+	 *
 	 * @param datas
 	 *            The collection of data items that we are creating in the database.
 	 * @return The number of rows updated in the database.
@@ -187,12 +187,12 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	 * This is a convenience method to creating a data item but only if the ID does not already exist in the table. This
 	 * extracts the id from the data parameter, does a {@link #queryForId(Object)} on it, returning the data if it
 	 * exists. If it does not exist {@link #create(Object)} will be called with the parameter.
-	 * 
+	 *
 	 * <p>
 	 * <b>NOTE:</b> This method is synchronized because otherwise race conditions would be encountered if this is used
 	 * by multiple threads.
 	 * </p>
-	 * 
+	 *
 	 * @return Either the data parameter if it was inserted (now with the ID field set via the create method) or the
 	 *         data element that existed already in the database.
 	 */
@@ -201,10 +201,11 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	/**
 	 * This is a convenience method to creating a data item but only if the ID does not already exist in the table. This
 	 * extracts the id from the data parameter, does a {@link #queryForId(Object)} on it, returning the data if it
-	 * exists. If it does not exist {@link #create(Object)} will be called with the parameter.
-	 *
-	 * Unlike {@link #createIfNotExists(Object)}, this method able to initialize a new object lazily.
-	 *
+	 * exists. If it does not exist {@link #create(Object)} will be called with the parameter obtained
+	 * from {@code dataSupplier}.
+	 * <p>
+	 * Unlike {@link #createIfNotExists(Object)}, this method creates a new object lazily (only if it's really necessary).
+	 * </p>
 	 * <p>
 	 * <b>NOTE:</b> This method is synchronized because otherwise race conditions would be encountered if this is used
 	 * by multiple threads.
@@ -213,7 +214,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	 * @return Either the data parameter if it was inserted (now with the ID field set via the create method) or the
 	 *         data element that existed already in the database.
 	 */
-	public T createIfNotExists(ID key, Supplier<T> dataSupplier) throws SQLException;
+	public T createIfNotExists(ID key, Supplier<T> entityCreator) throws SQLException;
 
 	/**
 	 * This is a convenience method for creating an item in the database if it does not exist. The id is extracted from
@@ -221,12 +222,12 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	 * then all of the columns in the database will be updated from the fields in the data parameter. If the id is null
 	 * (or 0 or some other default value) or doesn't exist in the database then the object will be created in the
 	 * database. This also means that your data item <i>must</i> have an id field defined.
-	 * 
+	 *
 	 * <p>
 	 * <b>NOTE:</b> This method is synchronized because otherwise race conditions would be encountered if this is used
 	 * by multiple threads.
 	 * </p>
-	 * 
+	 *
 	 * @return Status object with the number of rows changed and whether an insert or update was performed.
 	 */
 	public CreateOrUpdateStatus createOrUpdate(T data) throws SQLException;
@@ -235,11 +236,11 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	 * Store the fields from an object to the database row corresponding to the id from the data parameter. If you have
 	 * made changes to an object, this is how you persist those changes to the database. You cannot use this method to
 	 * update the id field -- see {@link #updateId} .
-	 * 
+	 *
 	 * <p>
 	 * NOTE: This will not save changes made to foreign objects or to foreign collections.
 	 * </p>
-	 * 
+	 *
 	 * @param data
 	 *            The data item that we are updating in the database.
 	 * @return The number of rows updated in the database. This should be 1.
@@ -254,11 +255,11 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	 * Update the data parameter in the database to change its id to the newId parameter. The data <i>must</i> have its
 	 * current (old) id set. If the id field has already changed then it cannot be updated. After the id has been
 	 * updated in the database, the id field of the data parameter will also be changed.
-	 * 
+	 *
 	 * <p>
 	 * <b>NOTE:</b> Depending on the database type and the id type, you may be unable to change the id of the field.
 	 * </p>
-	 * 
+	 *
 	 * @param data
 	 *            The data item that we are updating in the database with the current id.
 	 * @param newId
@@ -274,7 +275,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	 * {@link UpdateBuilder} must have set-columns applied to it using the
 	 * {@link UpdateBuilder#updateColumnValue(String, Object)} or
 	 * {@link UpdateBuilder#updateColumnExpression(String, String)} methods.
-	 * 
+	 *
 	 * @param preparedUpdate
 	 *            A prepared statement to match database rows to be deleted and define the columns to update.
 	 * @return The number of rows updated in the database.
@@ -289,7 +290,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	 * Does a query for the data parameter's id and copies in each of the field values from the database to refresh the
 	 * data parameter. Any local object changes to persisted fields will be overwritten. If the database has been
 	 * updated this brings your local object up to date.
-	 * 
+	 *
 	 * @param data
 	 *            The data item that we are refreshing with fields from the database.
 	 * @return The number of rows found in the database that correspond to the data id. This should be 1.
@@ -301,7 +302,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 
 	/**
 	 * Delete the database row corresponding to the id from the data parameter.
-	 * 
+	 *
 	 * @param data
 	 *            The data item that we are deleting from the database.
 	 * @return The number of rows updated in the database. This should be 1.
@@ -312,7 +313,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 
 	/**
 	 * Delete an object from the database that has an id.
-	 * 
+	 *
 	 * @param id
 	 *            The id of the item that we are deleting from the database.
 	 * @return The number of rows updated in the database. This should be 1.
@@ -324,7 +325,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	/**
 	 * Delete a collection of objects from the database using an IN SQL clause. The ids are extracted from the datas
 	 * parameter and used to remove the corresponding rows in the database with those ids.
-	 * 
+	 *
 	 * @param datas
 	 *            A collection of data items to be deleted.
 	 * @return The number of rows updated in the database. This should be the size() of the collection.
@@ -335,7 +336,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 
 	/**
 	 * Delete the objects that match the collection of ids from the database using an IN SQL clause.
-	 * 
+	 *
 	 * @param ids
 	 *            A collection of data ids to be deleted.
 	 * @return The number of rows updated in the database. This should be the size() of the collection.
@@ -346,7 +347,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 
 	/**
 	 * Delete the objects that match the prepared statement parameter.
-	 * 
+	 *
 	 * @param preparedDelete
 	 *            A prepared statement to match database rows to be deleted.
 	 * @return The number of rows updated in the database.
@@ -358,30 +359,30 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	/**
 	 * This satisfies the {@link Iterable} interface for the class and allows you to iterate through the objects in the
 	 * table using SQL. You can use code similar to the following:
-	 * 
+	 *
 	 * <pre>
 	 * for (Account account : accountDao) { ... }
 	 * </pre>
-	 * 
+	 *
 	 * <p>
 	 * <b>WARNING</b>: because the {@link Iterator#hasNext()}, {@link Iterator#next()}, etc. methods can only throw
 	 * {@link RuntimeException}, the code has to wrap any {@link SQLException} with {@link IllegalStateException}. Make
 	 * sure to catch {@link IllegalStateException} and look for a {@link SQLException} cause.
 	 * </p>
-	 * 
+	 *
 	 * <p>
 	 * <b>WARNING</b>: The underlying results object will only be closed if you page all the way to the end of the
 	 * iterator using the for() loop or if you call {@link CloseableIterator#close()} directly. You can also call the
 	 * {@link #closeLastIterator()} if you are not iterating across this DAO in multiple threads.
 	 * </p>
-	 * 
+	 *
 	 * <p>
 	 * <b>NOTE:</b> With this iterator you can only move forward through the object collection. See the
 	 * {@link #iterator(int)} method to create a cursor that can go both directions.
 	 * </p>
-	 * 
+	 *
 	 * @return An iterator of the class that uses SQL to step across the database table.
-	 * 
+	 *
 	 * @throws IllegalStateException
 	 *             When it encounters a SQLException or in other cases.
 	 */
@@ -391,7 +392,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	/**
 	 * Same as {@link #iterator()} but while specifying flags for the results. This is necessary with certain database
 	 * types. The resultFlags could be something like ResultSet.TYPE_SCROLL_INSENSITIVE or other values.
-	 * 
+	 *
 	 * <p>
 	 * <b>WARNING:</b> Depending on the database type the underlying connection may never be freed -- even if you go all
 	 * of the way through the results. It is <i>strongly</i> recommended that you call the
@@ -403,7 +404,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	/**
 	 * Same as {@link #iterator()} but with a prepared query parameter. See {@link #queryBuilder} for more information.
 	 * You use it like the following:
-	 * 
+	 *
 	 * <pre>
 	 * QueryBuilder&lt;Account, String&gt; qb = accountDao.queryBuilder();
 	 * ... custom query builder methods
@@ -417,7 +418,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	 *     iterator.close();
 	 * }
 	 * </pre>
-	 * 
+	 *
 	 * @param preparedQuery
 	 *            Query used to iterate across a sub-set of the items in the database.
 	 * @return An iterator for T.
@@ -438,7 +439,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	 * {@link CloseableWrappedIterable} but multiple threads can each call this to get their own closeable iterable.
 	 * This allows you to do something like:
 	 * </p>
-	 * 
+	 *
 	 * <pre>
 	 * CloseableWrappedIterable&lt;Foo&gt; wrappedIterable = fooDao.getWrappedIterable();
 	 * try {
@@ -460,7 +461,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 
 	/**
 	 * This closes the last iterator returned by the {@link #iterator()} method.
-	 * 
+	 *
 	 * <p>
 	 * <b>NOTE:</b> This is not reentrant. If multiple threads are getting iterators from this DAO then you should use
 	 * the {@link #getWrappedIterable()} method to get a wrapped iterable for each thread instead.
@@ -476,22 +477,22 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	 * on the returned RawResults object once you are done with it. The arguments are optional but can be set with
 	 * strings to expand ? type of SQL.
 	 * </p>
-	 * 
+	 *
 	 * <p>
 	 * You can use the {@link QueryBuilder#prepareStatementString()} method here if you want to build the query using
 	 * the structure of the QueryBuilder.
 	 * </p>
-	 * 
+	 *
 	 * <pre>
 	 * QueryBuilder&lt;Account, Integer&gt; qb = accountDao.queryBuilder();
 	 * qb.where().ge(&quot;orderCount&quot;, 10);
 	 * results = accountDao.queryRaw(qb.prepareStatementString());
 	 * </pre>
-	 * 
+	 *
 	 * <p>
 	 * If you want to use the QueryBuilder with arguments to the raw query then you should do something like:
 	 * </p>
-	 * 
+	 *
 	 * <pre>
 	 * QueryBuilder&lt;Account, Integer&gt; qb = accountDao.queryBuilder();
 	 * // we specify a SelectArg here to generate a ? in the statement string below
@@ -499,7 +500,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	 * // the 10 at the end is an optional argument to fulfill the SelectArg above
 	 * results = accountDao.queryRaw(qb.prepareStatementString(), rawRowMapper, 10);
 	 * </pre>
-	 * 
+	 *
 	 * <p>
 	 * <b>NOTE:</b> If you are using the {@link QueryBuilder#prepareStatementString()} to build your query, it may have
 	 * added the id column to the selected column list if the Dao object has an id you did not include it in the columns
@@ -550,7 +551,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	/**
 	 * Run a raw execute SQL statement to the database. The arguments are optional but can be set with strings to expand
 	 * ? type of SQL. If you have no arguments, you may want to call {@link #executeRawNoArgs(String)}.
-	 * 
+	 *
 	 * @return number of rows affected.
 	 */
 	public int executeRaw(String statement, String... arguments) throws SQLException;
@@ -558,7 +559,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	/**
 	 * Run a raw execute SQL statement on the database without any arguments. This may use a different mechanism to
 	 * execute the query depending on the database backend.
-	 * 
+	 *
 	 * @return number of rows affected.
 	 */
 	public int executeRawNoArgs(String statement) throws SQLException;
@@ -566,7 +567,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	/**
 	 * Run a raw update SQL statement to the database. The statement must be an SQL INSERT, UPDATE or DELETE
 	 * statement.The arguments are optional but can be set with strings to expand ? type of SQL.
-	 * 
+	 *
 	 * @return number of rows affected.
 	 */
 	public int updateRaw(String statement, String... arguments) throws SQLException;
@@ -576,13 +577,13 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	 * number of database operations at once -- maybe loading data from a file. This will turn off what databases call
 	 * "auto-commit" mode, run the call-able, and then re-enable "auto-commit". If auto-commit is not supported then a
 	 * transaction will be used instead.
-	 * 
+	 *
 	 * <p>
 	 * <b>NOTE:</b> If neither auto-commit nor transactions are supported by the database type then this may just call
 	 * the callable. Also, "commit()" is <i>not</i> called on the connection at all. If "auto-commit" is disabled then
 	 * this will leave it off and nothing will have been persisted.
 	 * </p>
-	 * 
+	 *
 	 * <p>
 	 * <b>NOTE:</b> Depending on your underlying database implementation and whether or not you are working with a
 	 * single database connection, this may synchronize internally to ensure that there are not race-conditions around
@@ -595,7 +596,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	/**
 	 * Return the string version of the object with each of the known field values shown. Useful for testing and
 	 * debugging.
-	 * 
+	 *
 	 * @param data
 	 *            The data item for which we are returning the toString information.
 	 */
@@ -604,7 +605,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	/**
 	 * Return true if the two parameters are equal. This checks each of the fields defined in the database to see if
 	 * they are equal. Useful for testing and debugging.
-	 * 
+	 *
 	 * @param data1
 	 *            One of the data items that we are checking for equality.
 	 * @param data2
@@ -648,7 +649,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	/**
 	 * Returns the number of rows in the table associated with the prepared query passed in. Depending on the size of
 	 * the table and the database type, this may be expensive and take a while.
-	 * 
+	 *
 	 * <p>
 	 * <b>NOTE:</b> If the query was prepared with the {@link QueryBuilder} then you should have called the
 	 * {@link QueryBuilder#setCountOf(boolean)} with true before you prepared the query. You may instead want to use
@@ -662,26 +663,26 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	 * Creates an empty collection and assigns it to the appropriate field in the parent object. This allows you to add
 	 * things to the collection from the start.
 	 * </p>
-	 * 
+	 *
 	 * <p>
 	 * For example let's say you have an Account which has the field:
 	 * </p>
-	 * 
+	 *
 	 * <pre>
 	 * &#064;ForeignCollectionField(columnName = &quot;orders&quot;)
 	 * Collection&lt;Order&gt; orders;
 	 * </pre>
-	 * 
+	 *
 	 * <p>
 	 * You would then call:
 	 * </p>
-	 * 
+	 *
 	 * <pre>
 	 * accoundDao.assignEmptyForeignCollection(account, &quot;orders&quot;);
 	 * // this would add it the collection and the internal DAO
 	 * account.orders.add(order1);
 	 * </pre>
-	 * 
+	 *
 	 * @param parent
 	 *            Parent object that will be associated with all items added to this collection if not already assigned.
 	 * @param fieldName
@@ -693,7 +694,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	/**
 	 * Like {@link #assignEmptyForeignCollection(Object, String)} but it returns the empty collection that you assign to
 	 * the appropriate field.
-	 * 
+	 *
 	 * <p>
 	 * <b>NOTE:</b> May be deprecated in the future.
 	 * </p>
@@ -704,7 +705,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	 * Call this with true to enable an object cache for the DAO. Set to false to disable any caching. It is (as of
 	 * 9/2011) one of the newer features of ORMLite. It keeps a {@link ReferenceObjectCache} of the objects (using
 	 * {@link WeakReference}) referenced by the DAO. No support for objects returned by the {@link #queryRaw} methods.
-	 * 
+	 *
 	 * @throws SQLException
 	 *             If the DAO's class does not have an id field which is required by the {@link ObjectCache}.
 	 */
@@ -714,7 +715,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	 * Same as {@link #setObjectCache(boolean)} except you specify the actual cache instance to use for the DAO. This
 	 * allows you to use a {@link ReferenceObjectCache} with {@link SoftReference} setting, the {@link LruObjectCache},
 	 * or inject your own cache implementation. Call it with null to disable the cache.
-	 * 
+	 *
 	 * @throws SQLException
 	 *             If the DAO's class does not have an id field which is required by the {@link ObjectCache}.
 	 */
@@ -759,7 +760,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	 * {@link #setAutoCommit(DatabaseConnection, boolean)} and other methods below. Chances are you should be using the
 	 * {@link #callBatchTasks(Callable)} instead of this method unless you know what you are doing.
 	 * </p>
-	 * 
+	 *
 	 * <p>
 	 * This allocates a connection for this specific thread that will be used in all other DAO operations. The thread
 	 * <i>must</i> call {@link #endThreadConnection(DatabaseConnection)} once it is done with the connection. It is
@@ -776,11 +777,11 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	 * {@link #setAutoCommit(DatabaseConnection, boolean)} and other methods below. Chances are you should be using the
 	 * {@link #callBatchTasks(Callable)} instead of this method unless you know what you are doing.
 	 * </p>
-	 * 
+	 *
 	 * <p>
 	 * This method is used to free the connection returned by the {@link #startThreadConnection()} above.
 	 * </p>
-	 * 
+	 *
 	 * @param connection
 	 *            Connection to be freed. If null then it will be a no-op.
 	 */
@@ -789,12 +790,12 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	/**
 	 * Set auto-commit mode to be true or false on the connection returned by the {@link #startThreadConnection()}. This
 	 * may not be supported by all database types.
-	 * 
+	 *
 	 * <p>
 	 * <b>WARNING:</b> Chances are you should be using the {@link #callBatchTasks(Callable)} instead of this method
 	 * unless you know what you are doing.
 	 * </p>
-	 * 
+	 *
 	 * <p>
 	 * <b>NOTE:</b> Depending on your underlying database implementation and whether or not you are working with a
 	 * single database connection, you may need to synchronize calls to here and calls to
@@ -815,12 +816,12 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	 * this will commit all changes to the database made from that point up to now on the connection returned by the
 	 * {@link #startThreadConnection()}. The changes will be written to the database and discarded. The connection will
 	 * continue to stay in the current auto-commit mode.
-	 * 
+	 *
 	 * <p>
 	 * <b>WARNING:</b> Chances are you should be using the {@link #callBatchTasks(Callable)} instead of this method
 	 * unless you know what you are doing.
 	 * </p>
-	 * 
+	 *
 	 * <p>
 	 * <b>NOTE:</b> Depending on your underlying database implementation and whether or not you are working with a
 	 * single database connection, you may need to synchronize calls to here and calls to
@@ -835,12 +836,12 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	 * this will roll-back and flush all changes to the database made from that point up to now on the connection
 	 * returned by the {@link #startThreadConnection()} . None of those changes will be written to the database and are
 	 * discarded. The connection will continue to stay in the current auto-commit mode.
-	 * 
+	 *
 	 * <p>
 	 * <b>WARNING:</b> Chances are you should be using the {@link #callBatchTasks(Callable)} instead of this method
 	 * unless you know what you are doing.
 	 * </p>
-	 * 
+	 *
 	 * <p>
 	 * <b>NOTE:</b> Depending on your underlying database implementation and whether or not you are working with a
 	 * single database connection, you may need to synchronize calls to here and calls to
@@ -881,7 +882,7 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	 * Notify any registered {@link DaoObserver}s that the underlying data may have changed. This is done automatically
 	 * when using {@link #create(Object)}, {@link #update(Object)}, or {@link #delete(Object)} type methods. Batch
 	 * methods will be notified once at the end of the batch, not for every statement in the batch.
-	 * 
+	 *
 	 * NOTE: The {@link #updateRaw(String, String...)} and other raw methods will _not_ call notify automatically. You
 	 * will have to call this method yourself after you use the raw methods to change the entities.
 	 */

--- a/src/main/java/com/j256/ormlite/dao/Dao.java
+++ b/src/main/java/com/j256/ormlite/dao/Dao.java
@@ -13,6 +13,7 @@ import com.j256.ormlite.field.DataType;
 import com.j256.ormlite.field.DatabaseField;
 import com.j256.ormlite.field.FieldType;
 import com.j256.ormlite.field.ForeignCollectionField;
+import com.j256.ormlite.misc.functional.Supplier;
 import com.j256.ormlite.stmt.DeleteBuilder;
 import com.j256.ormlite.stmt.GenericRowMapper;
 import com.j256.ormlite.stmt.PreparedDelete;
@@ -196,6 +197,23 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	 *         data element that existed already in the database.
 	 */
 	public T createIfNotExists(T data) throws SQLException;
+
+	/**
+	 * This is a convenience method to creating a data item but only if the ID does not already exist in the table. This
+	 * extracts the id from the data parameter, does a {@link #queryForId(Object)} on it, returning the data if it
+	 * exists. If it does not exist {@link #create(Object)} will be called with the parameter.
+	 *
+	 * Unlike {@link #createIfNotExists(Object)}, this method able to initialize a new object lazily.
+	 *
+	 * <p>
+	 * <b>NOTE:</b> This method is synchronized because otherwise race conditions would be encountered if this is used
+	 * by multiple threads.
+	 * </p>
+	 *
+	 * @return Either the data parameter if it was inserted (now with the ID field set via the create method) or the
+	 *         data element that existed already in the database.
+	 */
+	public T createIfNotExists(ID key, Supplier<T> dataSupplier) throws SQLException;
 
 	/**
 	 * This is a convenience method for creating an item in the database if it does not exist. The id is extracted from

--- a/src/main/java/com/j256/ormlite/dao/Dao.java
+++ b/src/main/java/com/j256/ormlite/dao/Dao.java
@@ -202,17 +202,18 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	 * This is a convenience method to creating a data item but only if the ID does not already exist in the table. This
 	 * extracts the id from the data parameter, does a {@link #queryForId(Object)} on it, returning the data if it
 	 * exists. If it does not exist {@link #create(Object)} will be called with the parameter obtained
-	 * from {@code entityCreator}.
+	 * from {@code entitySupplier}.
 	 * <p>
-	 * Unlike {@link #createIfNotExists(Object)}, this method creates a new object lazily (only if it's really necessary).
+	 * Unlike {@link #createIfNotExists(Object)}, this method creates a new object lazily
+	 * (only if the object does not exist in the database).
 	 * <p>
 	 * <b>NOTE:</b> This method is synchronized because otherwise race conditions would be encountered if this is used
 	 * by multiple threads.
 	 *
 	 * @return A data parameter that already existed in the database or
-	 * the result of an {@code entityCreator} sent to the database.
+	 * the result of an {@code entitySupplier} sent to the database.
 	 */
-	public T createIfNotExists(ID key, Supplier<T> entityCreator) throws SQLException;
+	public T createIfNotExists(ID key, Supplier<T> entitySupplier) throws SQLException;
 
 	/**
 	 * This is a convenience method for creating an item in the database if it does not exist. The id is extracted from

--- a/src/main/java/com/j256/ormlite/dao/Dao.java
+++ b/src/main/java/com/j256/ormlite/dao/Dao.java
@@ -202,17 +202,15 @@ public interface Dao<T, ID> extends CloseableIterable<T> {
 	 * This is a convenience method to creating a data item but only if the ID does not already exist in the table. This
 	 * extracts the id from the data parameter, does a {@link #queryForId(Object)} on it, returning the data if it
 	 * exists. If it does not exist {@link #create(Object)} will be called with the parameter obtained
-	 * from {@code dataSupplier}.
+	 * from {@code entityCreator}.
 	 * <p>
 	 * Unlike {@link #createIfNotExists(Object)}, this method creates a new object lazily (only if it's really necessary).
-	 * </p>
 	 * <p>
 	 * <b>NOTE:</b> This method is synchronized because otherwise race conditions would be encountered if this is used
 	 * by multiple threads.
-	 * </p>
 	 *
-	 * @return Either the data parameter if it was inserted (now with the ID field set via the create method) or the
-	 *         data element that existed already in the database.
+	 * @return A data parameter that already existed in the database or
+	 * the result of an {@code entityCreator} sent to the database.
 	 */
 	public T createIfNotExists(ID key, Supplier<T> entityCreator) throws SQLException;
 

--- a/src/main/java/com/j256/ormlite/misc/functional/Supplier.java
+++ b/src/main/java/com/j256/ormlite/misc/functional/Supplier.java
@@ -1,14 +1,18 @@
 package com.j256.ormlite.misc.functional;
 
 /**
- * This is a functional interface intended to support lambda expressions in ormlite.
+ * Represents a supplier of results.
+ *
+ * There is no requirement that a new or distinct result be returned each time the supplier is invoked.
+ *
+ * This is a functional interface intended to support lambda expressions in ormlite whose functional method is get().
  */
 public interface Supplier<T> {
 
     /**
-     * Gets a value.
+     * Gets a result.
      *
-     * @return a value
+     * @return a result
      */
     T get();
 }

--- a/src/main/java/com/j256/ormlite/misc/functional/Supplier.java
+++ b/src/main/java/com/j256/ormlite/misc/functional/Supplier.java
@@ -1,0 +1,14 @@
+package com.j256.ormlite.misc.functional;
+
+/**
+ * This is a functional interface intended to support lambda expressions in ormlite.
+ */
+public interface Supplier<T> {
+
+    /**
+     * Gets a value.
+     *
+     * @return a value
+     */
+    T get();
+}


### PR DESCRIPTION
Using `Dao#createIfNotExists(T)` can be inefficient due to object creation. A likely scenario is that the object is constantly being created, but almost never used, since the database already contains one.

I added `Dao#createIfNotExists(ID, Supplier<T>)` to be able to call this method with lazy initialization. In this case, the object will be created only when there is a real need.

Since the project uses Java 7, there are no functional interfaces like `Supplier`. So I implemented it myself in `misc.functional`. A similar approach is also taken by log4j. Users on Java 8+ will be able to use it as a full functional interface. On versions below, this will also be used without problems, but without lambdas, of course.

The implementation of `BaseDaoImpl#createIfNotExists(T)` has now also been rewritten for the new method, since they do the same thing. There should be no difference in performance (creating a functional interface is extremely cheap).


