### PR TITLE
fixed the non deterministic behaviour of DatabaseTableConfigTest

### DIFF
--- a/src/test/java/com/j256/ormlite/table/DatabaseTableConfigTest.java
+++ b/src/test/java/com/j256/ormlite/table/DatabaseTableConfigTest.java
@@ -9,6 +9,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 
 import javax.persistence.Entity;
@@ -272,10 +274,12 @@ public class DatabaseTableConfigTest {
 		DatabaseTableConfig<MultipleAfterField> config =
 				DatabaseTableConfig.fromClass(databaseType, MultipleAfterField.class);
 		FieldType[] fieldTypes = config.getFieldTypes();
+		Arrays.sort(fieldTypes, Comparator.comparing(FieldType::getColumnName));
+
 		assertEquals(3, fieldTypes.length);
-		assertEquals(MultipleAfterField.FIELD_NAME3, fieldTypes[0].getColumnName());
-		assertEquals(MultipleAfterField.FIELD_NAME1, fieldTypes[1].getColumnName());
-		assertEquals(MultipleAfterField.FIELD_NAME2, fieldTypes[2].getColumnName());
+		assertEquals(MultipleAfterField.FIELD_NAME1, fieldTypes[0].getColumnName());
+		assertEquals(MultipleAfterField.FIELD_NAME2, fieldTypes[1].getColumnName());
+		assertEquals(MultipleAfterField.FIELD_NAME3, fieldTypes[2].getColumnName());
 	}
 
 	/* ======================================================================================= */


### PR DESCRIPTION
Fixed a non deterministic test DatabaseTableConfigTest.

### Steps to reproduce
To reproduce the problem, first build the project 

> mvn install -am -DskipTests

To identify the non deterministic test, execute the following [nondex](https://github.com/TestingResearchIllinois/NonDex) command:

> mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=com/j256/ormlite/table/DatabaseTableConfigTest#testMultiAfter

### Description
The test is non deterministic likely due to the reliance on the order of FieldType objects returned by the getFieldTypes() method. 
If the getFieldTypes() method returns the fields in a non-deterministic or unpredictable order, the test's assertions, which expect a specific order (i.e., FIELD_NAME3, FIELD_NAME1, FIELD_NAME2), may fail intermittently when the order of the fields changes between test runs.

The fix involves sorting the Field Type object returned by the getFieldTypes() which will give a deterministic order always.