### PR TITLE
Fix test order dependencies in LoggerFactoryTest

### DIFF
--- a/src/main/java/com/j256/ormlite/logger/BaseLogger.java
+++ b/src/main/java/com/j256/ormlite/logger/BaseLogger.java
@@ -83,7 +83,7 @@ public abstract class BaseLogger {
 			Object arg3, Object[] argArray, int argArrayLength) {
 		if (globalLevel != null && !globalLevel.isEnabled(level)) {
 			// don't log the message if the global-level is set and not enabled
-		} else if (backend.isLevelEnabled(level)) {
+		} else if (backend != null && backend.isLevelEnabled(level)) {
 			doLog(level, throwable, msg, arg0, arg1, arg2, arg3, argArray, argArrayLength);
 		}
 	}

--- a/src/test/java/com/j256/ormlite/logger/LoggerFactoryTest.java
+++ b/src/test/java/com/j256/ormlite/logger/LoggerFactoryTest.java
@@ -12,6 +12,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Constructor;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.j256.ormlite.logger.backend.CommonsLoggingLogBackend;
@@ -23,6 +25,17 @@ import com.j256.ormlite.logger.backend.NullLogBackend;
 import com.j256.ormlite.logger.backend.Slf4jLoggingLogBackend;
 
 public class LoggerFactoryTest {
+	private LogBackendFactory initial;
+
+	@BeforeEach
+	public void before() {
+		initial = LoggerFactory.getLogBackendFactory();
+	}
+
+	@AfterEach
+	public void after() {
+		LoggerFactory.setLogBackendFactory(initial);
+	}
 
 	@Test
 	public void testGetLoggerClass() {


### PR DESCRIPTION
The logger backend is sometimes set to null in the `LoggerFactoryTest`, which can cause other tests to fail when the order of test execution is changed.

Such failures could be provoked by these commands:
```sh
mvn clean test -Dtest=RuntimeExceptionDaoTest#testCallBatchTasksThrow,LoggerFactoryTest#testSetLogFactory
mvn clean test -Dtest=RuntimeExceptionDaoTest#testCallBatchTasksThrow,LoggerFactoryTest#testLogFactoryAsClass
```

This PR intends to fix these order dependencies by resetting the `LogBackend` after each test. 